### PR TITLE
test: fix vitest import spacing

### DIFF
--- a/tests/utils/word-stats-utils.spec.js
+++ b/tests/utils/word-stats-utils.spec.js
@@ -1,4 +1,4 @@
-import { describe, expect,it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import {
   findWordDate,


### PR DESCRIPTION
## Summary
- align vitest import syntax in word stats util test

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890f7284fe8832a8e31955351cff82c