### PR TITLE
chore: clean up letter stats JSDoc

### DIFF
--- a/src/utils/word-stats-utils.ts
+++ b/src/utils/word-stats-utils.ts
@@ -67,12 +67,6 @@ export const getWordStats = (words: WordData[]): WordStatsResult => {
 };
 
 /**
- * Converts letter frequency data into sorted statistics.
- * @param {Record<string, number>} letterFrequency - Object mapping letters to their frequency counts
- * @returns {WordLetterStatsResult} Array of letter-frequency pairs sorted by frequency (descending)
- */
-
-/**
  * Converts letter word count data into sorted statistics, filtering to a-z only (case-insensitive).
  * @param {Record<string, number>} letterFrequency - Object mapping letters to count of words containing them
  * @returns {WordLetterStatsResult} Array of letter-wordcount pairs sorted by word count (descending), only a-z


### PR DESCRIPTION
## Summary
- remove outdated JSDoc block above `getLetterStats`

## Testing
- `npm run lint`
- `SITE_URL=http://example.com SITE_TITLE='Example' SITE_DESCRIPTION='Example' SITE_ID='example' npm run typecheck`
- `SITE_URL=http://example.com SITE_TITLE='Example' SITE_DESCRIPTION='Example' SITE_ID='example' npm run build` *(fails: The collection "words" does not exist or is empty)*

------
https://chatgpt.com/codex/tasks/task_e_6890f71e64b8832a9411baae304d05d2