### PR TITLE
Improve alphabetical sequence detection and tests

### DIFF
--- a/src/utils/text-utils.ts
+++ b/src/utils/text-utils.ts
@@ -23,7 +23,7 @@ export function hasTripleLetters(word: string): boolean {
  * Checks if a word contains any sequence of three consecutive alphabetical letters (e.g., 'abc', 'def').
  */
 export function hasAlphabeticalSequence(word: string): boolean {
-  const letters = word.split('');
+  const letters = word.toLowerCase().split('');
   for (let i = 0; i < letters.length - 2; i++) {
     const a = letters[i].charCodeAt(0);
     const b = letters[i + 1].charCodeAt(0);

--- a/tests/utils/text-utils.spec.js
+++ b/tests/utils/text-utils.spec.js
@@ -1,4 +1,4 @@
-import { describe, expect,it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import {
   countSyllables,
@@ -185,6 +185,20 @@ describe('text-utils', () => {
       expect(hasAlphabeticalSequence('jumpy')).toBe(false);
       expect(hasAlphabeticalSequence('abacus')).toBe(false); // a-b but then breaks with a-c
       expect(hasAlphabeticalSequence('jumped')).toBe(false); // no consecutive sequences
+    });
+  });
+
+  describe('hasAlphabeticalSequence (~utils)', () => {
+    it('detects sequences in lowercase words', () => {
+      expect(hasAlphabeticalSequence('lmn')).toBe(true);
+    });
+
+    it('detects sequences in mixed-case words', () => {
+      expect(hasAlphabeticalSequence('aBc')).toBe(true);
+    });
+
+    it('returns false when no sequence exists', () => {
+      expect(hasAlphabeticalSequence('abd')).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary
- make `hasAlphabeticalSequence` case-insensitive in client text utils
- consolidate imports and extend tests for lowercase, mixed-case, and negative scenarios
- remove unused shared text util

## Testing
- `npm run lint`
- `SITE_URL=http://example.com SITE_TITLE=Test SITE_DESCRIPTION=Desc SITE_ID=1 npm run typecheck`
- `SITE_URL=http://example.com SITE_TITLE=Test SITE_DESCRIPTION=Desc SITE_ID=1 npm run build` (fails: The collection "words" does not exist or is empty. Word not found)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890f71fa518832abc2a66b213a5aa97