### PR TITLE
refactor: use alias for wordnik logo

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,7 +1,6 @@
 ---
+import wordnikLogo from '~/assets/wordnik-gearheart.png';
 import SiteLink from '~components/SiteLink.astro';
-
-import wordnikLogo from '../assets/wordnik-gearheart.png';
 
 const currentYear = new Date().getFullYear();
 const attributionUrl = import.meta.env.SITE_AUTHOR_URL;


### PR DESCRIPTION
## Summary
- use alias import for Wordnik logo in footer

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689224523e34832a8c37e2c2dbfaac64