### PR TITLE
test: use alias for word stats utils

### DIFF
--- a/tests/utils/word-stats-utils.spec.js
+++ b/tests/utils/word-stats-utils.spec.js
@@ -11,7 +11,7 @@ import {
   getSyllableStats,
   getWordEndingStats,
   getWordStats,
-} from '../../src/utils/word-stats-utils';
+} from '~utils-client/word-stats-utils';
 
 const sampleWords = [
   { word: 'hello', date: '20240101' },


### PR DESCRIPTION
## Summary
- use `~utils-client` alias in word-stats-utils test

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892245598d0832a804e1c5f88e5013f