### PR TITLE
refactor: streamline error logging

### DIFF
--- a/tools/add-word.ts
+++ b/tools/add-word.ts
@@ -20,7 +20,7 @@ const checkExistingWord = (date: string): WordData | null => {
       const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
       return data as WordData;
     } catch (error) {
-      console.error('Error reading existing word file', { filePath, error: (error as Error).message });
+      console.error('Failed to read existing word file', { filePath, error: (error as Error).message });
     }
   }
   return null;
@@ -158,7 +158,7 @@ if (hasOverwrite) {
 const [word, date] = args;
 
 if (!word) {
-  console.error('Error: Word is required');
+  console.error('Word is required');
   showHelp(HELP_TEXT);
   process.exit(1);
 }

--- a/tools/generate-images.ts
+++ b/tools/generate-images.ts
@@ -56,7 +56,7 @@ async function generateSingleImage(word: string): Promise<boolean> {
     console.log('Generated image for word', { word, date: wordData.date });
     return true;
   } catch (error) {
-    console.error('Error generating image for word', { word, error: (error as Error).message });
+    console.error('Failed to generate image for word', { word, error: (error as Error).message });
     return false;
   }
 }
@@ -77,7 +77,7 @@ async function generateAllImages(): Promise<void> {
       console.log('Generated image', { word: wordData.word, date: wordData.date });
       successCount++;
     } catch (error) {
-      console.error('Error generating image', {
+      console.error('Failed to generate image', {
         word: wordData.word,
         date: wordData.date,
         error: (error as Error).message,
@@ -137,7 +137,7 @@ async function generateGenericImages(): Promise<void> {
       console.log('Generated generic image', { title: page.title, path: page.path });
       successCount++;
     } catch (error) {
-      console.error('Error generating generic image', {
+      console.error('Failed to generate generic image', {
         title: page.title,
         path: page.path,
         error: (error as Error).message,
@@ -170,7 +170,7 @@ async function generatePageImage(pagePath: string): Promise<boolean> {
     console.log('Generated page image', { title: page.title, path: page.path });
     return true;
   } catch (error) {
-    console.error('Error generating page image', { pagePath, error: (error as Error).message });
+    console.error('Failed to generate page image', { pagePath, error: (error as Error).message });
     return false;
   }
 }

--- a/tools/ping-search-engines.ts
+++ b/tools/ping-search-engines.ts
@@ -43,7 +43,7 @@ const siteUrlArg = getArgValue('--site-url', args);
 const deployedHashArg = getArgValue('--deployed-hash', args);
 
 if (!siteUrlArg) {
-  console.error('Error: Missing required argument: --site-url is required.');
+  console.error('Missing required argument', { argument: '--site-url' });
   process.exit(1);
 }
 

--- a/tools/regenerate-all-words.ts
+++ b/tools/regenerate-all-words.ts
@@ -160,7 +160,7 @@ async function regenerateAllWords(options: RegenerateOptions): Promise<void> {
           await new Promise(resolve => setTimeout(resolve, options.timeout));
         }
       } catch (error) {
-        console.error(`Error processing ${item.word}:`, (error as Error).message);
+        console.error(`Failed to process ${item.word}`, { error: (error as Error).message });
         failureCount++;
       }
     }
@@ -171,7 +171,7 @@ async function regenerateAllWords(options: RegenerateOptions): Promise<void> {
     console.log(`Total processed: ${successCount + failureCount} words`);
 
   } catch (error) {
-    console.error('Error regenerating words:', (error as Error).message);
+    console.error('Failed to regenerate words', { error: (error as Error).message });
     process.exit(1);
   }
 }

--- a/tools/utils.ts
+++ b/tools/utils.ts
@@ -68,12 +68,12 @@ export const getWordFiles = (): WordFileInfo[] => {
             path: filePath,
           };
         } catch (error) {
-          console.error('Error reading word file', { file, error: (error as Error).message });
+          console.error('Failed to read word file', { file, error: (error as Error).message });
           return null;
         }
       }).filter(Boolean) as WordFileInfo[];
     } catch (error) {
-      console.error('Error reading year directory', { year, error: (error as Error).message });
+      console.error('Failed to read year directory', { year, error: (error as Error).message });
       return [];
     }
   });


### PR DESCRIPTION
## Summary
- remove redundant "Error" prefixes from console.error calls
- attach context objects for clearer logs in tools

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689224de1b40832a8f677f064517de24