### PR TITLE
docs: remove barrel export optimization note

### DIFF
--- a/docs/potential-features.md
+++ b/docs/potential-features.md
@@ -62,11 +62,6 @@ if (!siteUrl) throw new Error('SITE_URL required');
 **Impact**: Medium - Risk of regressions in untested code
 **Solution**: Add comprehensive test coverage for all utilities
 
-### Import Statement Optimization [LOW-MEDIUM PRIORITY]
-**Current Issue**: Some barrel exports and re-export patterns could be more direct
-**Impact**: Low-Medium - Affects tree-shaking and bundle size
-**Solution**: Prefer direct imports where possible
-
 ### Logging Strategy Enhancement [LOW PRIORITY]
 **Current State**: Console-based logging works but could be more structured
 - No log levels beyond console methods


### PR DESCRIPTION
## Summary
- remove outdated note about barrel export optimizations

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68937383ac70832ab1b9f211e3c57521