### PR TITLE
Add JSDoc coverage and document algorithms

### DIFF
--- a/config/paths.ts
+++ b/config/paths.ts
@@ -19,6 +19,10 @@ const getImagesPath = (): string => {
   return sourceDir ? path.join(ROOT, 'public', sourceDir, 'images') : path.join(ROOT, 'public', 'images');
 };
 
+/**
+ * Create resolved paths used across the application
+ * @returns {PathConfig} Object containing absolute paths for words, pages, images and fonts
+ */
 export const createPaths = (): PathConfig => ({
   words: getWordsPath(),
   pages: path.join(ROOT, 'src', 'pages'),

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -342,6 +342,14 @@ const sortedWords = words
 - Supports different data sources via `{SOURCE_DIR}` environment variable
 - Enables flexible deployment to different environments
 
+## Complex Algorithms & Architectural Decisions
+
+### Statistics Generation
+Word statistics are derived from raw word data using specialized helpers in `src/utils/word-stats-utils.ts`. Functions such as `getCurrentStreakStats` and `getChronologicalMilestones` walk the dataset to compute streaks, letter patterns and milestone words without mutating the source array. These algorithms favor readability and immutability while still handling large word lists efficiently.
+
+### Dynamic Static Path Creation
+The `generateStatsStaticPaths` utility builds Astro static paths based on available statistics. It loads all words at runtime, filters out empty stat pages when the `__SHOW_EMPTY_STATS__` flag is disabled and maps each stat definition to its route and data payload. This ensures only meaningful pages are generated and keeps the build output lean.
+
 ## Performance Optimizations
 
 ### Build-time Optimizations

--- a/src/pages/health.txt.ts
+++ b/src/pages/health.txt.ts
@@ -3,6 +3,10 @@ import type { APIRoute } from 'astro';
 import { generateHealthTxt } from '~utils-client/static-file-utils';
 import { getWordsFromCollection } from '~utils-client/word-data-utils';
 
+/**
+ * Handle health.txt requests
+ * @returns {Promise<Response>} plain text health.txt content
+ */
 export const GET: APIRoute = async () => {
   const allWords = await getWordsFromCollection();
   const healthTxt = generateHealthTxt(allWords);

--- a/src/pages/humans.txt.ts
+++ b/src/pages/humans.txt.ts
@@ -2,6 +2,10 @@ import type { APIRoute } from 'astro';
 
 import { generateHumansTxt } from '~utils-client/static-file-utils';
 
+/**
+ * Handle humans.txt requests
+ * @returns {Response} plain text humans.txt content
+ */
 export const GET: APIRoute = () => {
   const humansTxt = generateHumansTxt();
 

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -3,6 +3,10 @@ import type { APIRoute } from 'astro';
 import { generateLlmsTxt } from '~utils-client/static-file-utils';
 import { getWordsFromCollection } from '~utils-client/word-data-utils';
 
+/**
+ * Handle llms.txt requests
+ * @returns {Promise<Response>} plain text llms.txt content
+ */
 export const GET: APIRoute = async () => {
   const allWords = await getWordsFromCollection();
   const llmsTxt = generateLlmsTxt(allWords);

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -2,6 +2,10 @@ import type { APIRoute } from 'astro';
 
 import { generateRobotsTxt } from '~utils-client/static-file-utils';
 
+/**
+ * Handle robots.txt requests
+ * @returns {Response} plain text robots.txt content
+ */
 export const GET: APIRoute = () => {
   const siteUrl = import.meta.env.SITE_URL;
   if (!siteUrl) {

--- a/src/utils/image-utils.ts
+++ b/src/utils/image-utils.ts
@@ -2,6 +2,8 @@ import type { WordData } from '~types/word';
 
 /**
  * Get social media image URL for a word or page
+ * @param {{ pathname: string; wordData?: WordData | null }} params - Pathname and optional word data
+ * @returns {string} URL to the social image
  */
 export function getSocialImageUrl({ pathname, wordData }: { pathname: string; wordData?: WordData | null }): string {
   const basePath = import.meta.env.BASE_PATH || '/';
@@ -24,6 +26,7 @@ export function getSocialImageUrl({ pathname, wordData }: { pathname: string; wo
 
 /**
  * Get static pages for image generation
+ * @returns {Promise<unknown>} Metadata for all static pages
  */
 export async function getStaticPages() {
   const { getAllPageMetadata } = await import('~utils-client/page-metadata');

--- a/src/utils/page-metadata.ts
+++ b/src/utils/page-metadata.ts
@@ -255,7 +255,12 @@ function getCountForPath(path: string, words: WordData[] = allWords): number {
   }
 }
 
-
+/**
+ * Get metadata for a specific page path
+ * @param {string} [pathname] - Path of the page
+ * @param {WordData[]} [words=allWords] - Word dataset to evaluate
+ * @returns {Record<string, unknown>} Metadata including title and description
+ */
 export function getPageMetadata(pathname?: string, words: WordData[] = allWords) {
   if (!pathname) {
 throw new Error('getPageMetadata: pathname is required. Pass Astro.url.pathname from your page.');
@@ -307,6 +312,11 @@ throw new Error('getPageMetadata: pathname is required. Pass Astro.url.pathname 
   }
 }
 
+/**
+ * Get metadata for all pages
+ * @param {WordData[]} [words=allWords] - Word dataset to evaluate
+ * @returns {Array<{ path: string } & Record<string, unknown>>} Array of metadata objects
+ */
 export function getAllPageMetadata(words: WordData[] = allWords) {
   const showEmptyPages = (globalThis as Record<string, unknown>).__SHOW_EMPTY_STATS__ || false;
   const PAGE_METADATA = createPageMetadata(words);

--- a/src/utils/schema-utils.ts
+++ b/src/utils/schema-utils.ts
@@ -16,6 +16,7 @@ export type StructuredDataType = typeof STRUCTURED_DATA_TYPE[keyof typeof STRUCT
 
 /**
  * Global website schema data - included on every page
+ * @returns {WebSiteSchema} Base schema.org website data
  */
 export function getWebsiteSchemaData(): WebSiteSchema {
   return {
@@ -38,6 +39,8 @@ export function getWebsiteSchemaData(): WebSiteSchema {
 
 /**
  * Generate word schema data from word details
+ * @param {WordSchemaData} wordData - Word details to serialize
+ * @returns {DefinedTermSchema | null} Schema data or null when invalid
  */
 export function getWordSchemaData(wordData: WordSchemaData): DefinedTermSchema | null {
   if (!wordData || !wordData.word) {
@@ -76,6 +79,10 @@ return null;
 
 /**
  * Generate collection schema data
+ * @param {string} name - Collection name
+ * @param {string} description - Description of collection
+ * @param {number} itemCount - Number of items in the collection
+ * @returns {CollectionPageSchema} Schema data for the collection page
  */
 export function getCollectionSchemaData(name: string, description: string, itemCount: number): CollectionPageSchema {
   return {

--- a/src/utils/sentry-client.ts
+++ b/src/utils/sentry-client.ts
@@ -4,6 +4,10 @@ import type { LogContext } from '~types/common';
 
 /**
  * Log an error to Sentry with optional context
+ * @param {Error | string} error - Error object or message
+ * @param {LogContext} [context={}] - Additional context for the log
+ * @param {'error' | 'warning' | 'info'} [level='error'] - Severity level
+ * @returns {void} Nothing
  */
 export function logError(error: Error | string, context: LogContext = {}, level: 'error' | 'warning' | 'info' = 'error'): void {
   if (import.meta.env.SENTRY_ENABLED !== 'true') {
@@ -31,6 +35,11 @@ export function logError(error: Error | string, context: LogContext = {}, level:
 
 /**
  * Log a structured error to Sentry with use case identification
+ * @param {string} useCase - Identifier for where the error occurred
+ * @param {LogContext} [params={}] - Additional parameters for context
+ * @param {Error} [error] - Original error instance
+ * @param {'error' | 'warning' | 'info'} [level='error'] - Severity level
+ * @returns {void} Nothing
  */
 export function logSentryError(useCase: string, params: LogContext = {}, error?: Error, level: 'error' | 'warning' | 'info' = 'error'): void {
   const message = error instanceof Error ? error : `Error: ${useCase}`;

--- a/src/utils/seo-utils.ts
+++ b/src/utils/seo-utils.ts
@@ -21,6 +21,8 @@ export const seoConfig: SeoConfig = {
 
 /**
  * Generate page-specific meta description
+ * @param {SeoMetaDescriptionOptions} [options={}] - Description options
+ * @returns {string} Generated meta description
  */
 export function getMetaDescription(options: SeoMetaDescriptionOptions = {}): string {
   const { word, definition, custom } = options;
@@ -41,6 +43,8 @@ return custom;
 
 /**
  * Generate basic SEO metadata for a page
+ * @param {SeoMetadataOptions} param0 - Metadata options
+ * @returns {SeoMetadata} SEO metadata object
  */
 export function generateSeoMetadata({ title, description, pathname, keywords = [] }: SeoMetadataOptions): SeoMetadata {
   const pageTitle = title ? `${title} - ${seoConfig.siteName}` : seoConfig.defaultTitle;

--- a/src/utils/static-file-utils.ts
+++ b/src/utils/static-file-utils.ts
@@ -2,6 +2,8 @@ import type { WordData } from '~types/word';
 
 /**
  * Generate robots.txt content
+ * @param {string} siteUrl - Base site URL
+ * @returns {string} robots.txt contents
  */
 export function generateRobotsTxt(siteUrl: string): string {
   return `User-agent: *
@@ -12,6 +14,7 @@ Sitemap: ${siteUrl}/sitemap-index.xml`;
 
 /**
  * Generate humans.txt content
+ * @returns {string} humans.txt contents
  */
 export function generateHumansTxt(): string {
   return `/* TEAM */
@@ -32,6 +35,8 @@ Standards: HTML5, CSS3
 
 /**
  * Generate health.txt content showing system status
+ * @param {WordData[]} words - All available word data
+ * @returns {string} health.txt contents
  */
 export function generateHealthTxt(words: WordData[]): string {
   return `Status: OK
@@ -41,6 +46,8 @@ Last Updated: ${new Date().toISOString()}`;
 
 /**
  * Generate llms.txt content for AI training data
+ * @param {WordData[]} words - All available word data
+ * @returns {string} llms.txt contents
  */
 export function generateLlmsTxt(words: WordData[]): string {
   return `# Occasional Word of the Day
@@ -60,6 +67,7 @@ Please respect attribution requirements for dictionary sources.`;
 
 /**
  * Get ASCII art for site header
+ * @returns {string} ASCII art string
  */
 export function getAsciiArt(): string {
   return `

--- a/src/utils/static-paths-utils.ts
+++ b/src/utils/static-paths-utils.ts
@@ -132,7 +132,10 @@ const createStatsConfig = (words: WordData[]): StatsConfig[] => {
     },
   ];
 };
-
+/**
+ * Generate Astro static paths for statistics pages
+ * @returns {Promise<Array<{ params: { stat: string }; props: Record<string, unknown> }>>} Array of path definitions for stats pages
+ */
 export const generateStatsStaticPaths = async () => {
   const { getWordsFromCollection } = await import('~utils-client/word-data-utils');
   const words = await getWordsFromCollection();

--- a/src/utils/stats-definitions.ts
+++ b/src/utils/stats-definitions.ts
@@ -162,6 +162,11 @@ export const DYNAMIC_STATS_DEFINITIONS: Record<string, DynamicStatsDefinition> =
 } as const;
 
 // Helper function to get stats definition by key
+/**
+ * Retrieve a stats definition by slug key
+ * @param {string} key - Stats slug
+ * @returns {unknown} Stats definition or undefined if not found
+ */
 export function getStatsDefinition(key: string) {
   // Check suffix definitions
   for (const [suffix, def] of Object.entries(SUFFIX_DEFINITIONS)) {

--- a/src/utils/text-utils.ts
+++ b/src/utils/text-utils.ts
@@ -1,28 +1,36 @@
 import type { TextProcessingOverrides } from '~types/common';
 
 /**
- * Checks if a word starts and ends with the same letter (length > 1).
+ * Check if a word starts and ends with the same letter
+ * @param {string} word - Word to evaluate
+ * @returns {boolean} True if first and last letters match and length > 1
  */
 export function isStartEndSame(word: string): boolean {
   return word.length > 1 && word[0] === word[word.length - 1];
 }
 
 /**
- * Checks if a word contains double letters (e.g., 'letter').
+ * Determine whether a word contains double letters
+ * @param {string} word - Word to inspect
+ * @returns {boolean} True if the word has any repeated consecutive letters
  */
 export function hasDoubleLetters(word: string): boolean {
   return /(.)(\1)/.test(word);
 }
 
 /**
- * Checks if a word contains triple (or more) consecutive letters (e.g., 'bookkeeper').
+ * Determine whether a word contains triple or more consecutive letters
+ * @param {string} word - Word to inspect
+ * @returns {boolean} True if the word has three or more repeated letters in a row
  */
 export function hasTripleLetters(word: string): boolean {
   return /(.)(\1){2,}/.test(word);
 }
 
 /**
- * Checks if a word contains any sequence of three consecutive alphabetical letters (e.g., 'abc', 'def').
+ * Check for any sequence of three consecutive alphabetical letters
+ * @param {string} word - Word to analyze
+ * @returns {boolean} True if any three-letter sequence is alphabetical
  */
 export function hasAlphabeticalSequence(word: string): boolean {
   const letters = word.toLowerCase().split('');
@@ -38,7 +46,9 @@ export function hasAlphabeticalSequence(word: string): boolean {
 }
 
 /**
- * Returns an array of common word endings the word matches (e.g., ['ing', 'ed']).
+ * Get common word endings matched by a word (e.g., "ing", "ed")
+ * @param {string} word - Word to examine
+ * @returns {string[]} Array of endings matched by the word
  */
 export function getWordEndings(word: string): string[] {
   const endings = ['ing', 'ed', 'ly', 'ness', 'ful', 'less'];

--- a/src/utils/url-utils.ts
+++ b/src/utils/url-utils.ts
@@ -1,8 +1,10 @@
 import { logger } from '~utils-client/logger';
 
 /**
- * Constructs a URL with the base URL if configured
+ * Construct a URL with the configured base path
  * Consistently enforces lowercase URLs and no trailing slashes except for root path
+ * @param {string} [path='/'] - Path to normalize
+ * @returns {string} Normalized URL path
  */
 export const getUrl = (path = '/'): string => {
   const baseUrl = import.meta.env.BASE_PATH || '/';
@@ -31,9 +33,10 @@ export const getUrl = (path = '/'): string => {
 };
 
 /**
- * Gets a normalized full URL including site URL and path
- * For use in canonicals, social tags, and other absolute URL needs
+ * Get a normalized full URL including site URL and path
  * Uses getUrl() internally to ensure BASE_PATH is properly handled
+ * @param {string} [path='/'] - Path to append to site URL
+ * @returns {string} Absolute URL
  */
 export const getFullUrl = (path = '/'): string => {
   const siteUrl = import.meta.env.SITE_URL?.replace(/\/$/, '') || '';
@@ -48,7 +51,9 @@ export const getFullUrl = (path = '/'): string => {
 };
 
 /**
- * Creates a consistent, SEO-friendly internal link URL
+ * Create a consistent, SEO-friendly internal link URL for a word
+ * @param {string} word - Word to build URL for
+ * @returns {string} Normalized word URL
  */
 export const getWordUrl = (word: string): string => {
   return word ? getUrl(`/words/${word}`) : '';

--- a/tools/help-utils.ts
+++ b/tools/help-utils.ts
@@ -5,6 +5,8 @@
 
 /**
  * Displays help text with consistent formatting
+ * @param {string} helpText - Raw help text to display
+ * @returns {void} Nothing
  */
 export function showHelp(helpText: string): void {
   console.log(helpText.trim());

--- a/tools/utils.ts
+++ b/tools/utils.ts
@@ -29,16 +29,16 @@ const regularFont = opentype.loadSync(path.join(paths.fonts, 'opensans', 'OpenSa
 const boldFont = opentype.loadSync(path.join(paths.fonts, 'opensans', 'OpenSans-ExtraBold.ttf'));
 
 
-/**
- * Gets all word files from the data directory
- * @returns Array of word file information objects
- */
 interface WordFileInfo {
   word: string;
   date: string;
   path: string;
 }
 
+/**
+ * Get all word files from the data directory
+ * @returns {WordFileInfo[]} Array of word file information objects
+ */
 export const getWordFiles = (): WordFileInfo[] => {
   if (!fs.existsSync(paths.words)) {
     console.error('Word directory does not exist', { path: paths.words });
@@ -89,6 +89,7 @@ export const getWordFiles = (): WordFileInfo[] => {
  * @param filePath - Path to the word file
  * @param data - Wordnik API response data
  * @param date - Date string in YYYYMMDD format
+ * @returns {void} Nothing
  */
 export function updateWordFile(filePath: string, data: WordnikResponse, date: string): void {
   if (!data.length || !data[0].word) {
@@ -112,6 +113,7 @@ export function updateWordFile(filePath: string, data: WordnikResponse, date: st
 /**
  * Creates a directory if it doesn't already exist
  * @param dir - Directory path to create
+ * @returns {void} Nothing
  */
 export function createDirectoryIfNeeded(dir: string): void {
   if (!fs.existsSync(dir)) {
@@ -256,6 +258,7 @@ export function createWordSvg(word: string, date: string): string {
  * Generates a social share image for a word
  * @param word - The word to generate an image for
  * @param date - Date string in YYYYMMDD format
+ * @returns {Promise<void>} Nothing
  */
 export async function generateShareImage(word: string, date: string): Promise<void> {
   const year = date.slice(0, 4);
@@ -320,6 +323,7 @@ export function createGenericSvg(title: string): string {
  * Generates a generic social share image for pages without a word
  * @param title - The title to use in the image
  * @param slug - The page slug/path
+ * @returns {Promise<void>} Nothing
  */
 export async function generateGenericShareImage(title: string, slug: string): Promise<void> {
   const socialDir = path.join(paths.images, 'social', 'pages');

--- a/utils/date-utils.ts
+++ b/utils/date-utils.ts
@@ -1,7 +1,9 @@
 import { format, isValid, parse, startOfDay } from 'date-fns';
 
 /**
- * Validates if a date string is in correct YYYYMMDD format
+ * Validate if a date string is in YYYYMMDD format
+ * @param {string} dateStr - Date string to validate
+ * @returns {boolean} True when the string represents a valid date
  */
 export const isValidDate = (dateStr: string): boolean => {
   const date = parse(dateStr, 'yyyyMMdd', new Date());
@@ -9,14 +11,17 @@ export const isValidDate = (dateStr: string): boolean => {
 };
 
 /**
- * Gets the current date in YYYYMMDD format
+ * Get today's date in YYYYMMDD format
+ * @returns {string} Current date as YYYYMMDD
  */
 export const getTodayYYYYMMDD = (): string => {
   return format(new Date(), 'yyyyMMdd');
 };
 
 /**
- * Formats a date string into a localized date
+ * Format a YYYYMMDD string into a human-friendly date
+ * @param {string} dateStr - Date string to format
+ * @returns {string} Formatted date or original string if invalid
  */
 export const formatDate = (dateStr: string): string => {
   if (!dateStr) {
@@ -32,14 +37,18 @@ export const formatDate = (dateStr: string): string => {
 };
 
 /**
- * Converts a Date object to YYYYMMDD format string
+ * Convert a Date object to a YYYYMMDD string
+ * @param {Date} date - Date to convert
+ * @returns {string} Converted date string
  */
 export const dateToYYYYMMDD = (date: Date): string => {
   return format(date, 'yyyyMMdd');
 };
 
 /**
- * Converts YYYYMMDD string to Date object
+ * Convert a YYYYMMDD string to a Date object
+ * @param {string} dateStr - Date string to convert
+ * @returns {Date | null} Date object or null if invalid
  */
 export const YYYYMMDDToDate = (dateStr: string): Date | null => {
   const date = parse(dateStr, 'yyyyMMdd', new Date());


### PR DESCRIPTION
## Summary
- document complex statistics and path generation algorithms
- add parameter and return JSDoc for public functions

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689373976dcc832a8042f57d31cb0f46