### PR TITLE
refactor: consolidate stats types

### DIFF
--- a/types/stats.ts
+++ b/types/stats.ts
@@ -1,32 +1,19 @@
 /**
- * Base stats definition structure
+ * Base stats definition supporting both static and dynamic descriptions
  */
 export interface StatsDefinition {
   title: string;
-  pageDescription: string;
-  metaDescription: (count: number) => string;
-  category: 'stats';
-}
-
-/**
- * Static stats definition with string-only meta description
- */
-export interface StaticStatsDefinition {
-  title: string;
-  pageDescription: string;
-  metaDescription: string;
-  category: 'stats';
-}
-
-/**
- * Dynamic stats definition with function-based descriptions
- */
-export interface DynamicStatsDefinition {
-  title: string;
-  pageDescription: (arg?: string | number) => string;
+  pageDescription: string | ((arg?: string | number) => string);
   metaDescription: (count: number, arg?: string) => string;
   category: 'stats';
 }
+
+/**
+ * Stats definition variant requiring dynamic descriptions
+ */
+export type DynamicStatsDefinition = StatsDefinition & {
+  pageDescription: (arg?: string | number) => string;
+};
 
 /**
  * Available word suffix patterns

--- a/types/word.ts
+++ b/types/word.ts
@@ -75,10 +75,6 @@ export interface WordGroupByYearResult {
   [year: string]: WordData[];
 }
 
-export interface WordFileGlobImport {
-  [path: string]: WordData | WordData[];
-}
-
 export interface WordMilestoneItem extends WordData {
   label: string;
 }


### PR DESCRIPTION
## Summary
- simplify stats definitions by supporting static or dynamic descriptions in a single interface
- drop unused WordFileGlobImport interface from word types

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68937338e664832ab0dbdfab01152609