### PR TITLE
Add word length pages and utilities

### DIFF
--- a/src/pages/words/length/[length].astro
+++ b/src/pages/words/length/[length].astro
@@ -1,0 +1,33 @@
+---
+import Heading from '~components/Heading.astro';
+import WordList from '~components/WordList.astro';
+import Layout from '~layouts/Layout.astro';
+import { getPageMetadata } from '~utils-client/page-metadata.ts';
+import { STRUCTURED_DATA_TYPE } from '~utils-client/schema-utils.ts';
+import { formatWordCount } from '~utils-client/text-utils';
+import { getAvailableLengths, getWordsByLength, getWordsFromCollection } from '~utils-client/word-data-utils';
+
+export async function getStaticPaths() {
+  const allWords = await getWordsFromCollection();
+  const lengths = getAvailableLengths(allWords);
+
+  return lengths.map(length => ({
+    params: { length: length.toString() },
+    props: { length, words: getWordsByLength(length, allWords) },
+  }));
+}
+
+const { length, words } = Astro.props;
+const { title, description } = getPageMetadata(Astro.url.pathname);
+const headingText = `${length}-letter words`;
+const wordCountText = formatWordCount(words.length);
+---
+
+<Layout title={title} description={description} structuredDataType={STRUCTURED_DATA_TYPE.WORD_LIST}>
+  <main class="main__content">
+    <Heading level={1} text={headingText} secondaryText={wordCountText} />
+    <WordList words={words} columns={2} />
+  </main>
+</Layout>
+
+

--- a/src/pages/words/length/index.astro
+++ b/src/pages/words/length/index.astro
@@ -1,0 +1,43 @@
+---
+import Heading from '~components/Heading.astro';
+import SiteLink from '~components/SiteLink.astro';
+import Layout from '~layouts/Layout.astro';
+import { getPageMetadata } from '~utils-client/page-metadata.ts';
+import { formatWordCount } from '~utils-client/text-utils';
+import { getAvailableLengths, getWordsFromCollection, groupWordsByLength } from '~utils-client/word-data-utils';
+
+const allWords = await getWordsFromCollection();
+const lengths = getAvailableLengths(allWords);
+const wordsByLength = groupWordsByLength(allWords);
+const { title, description } = getPageMetadata(Astro.url.pathname);
+const lengthLinks = lengths.map(length => ({
+  length,
+  countText: formatWordCount(wordsByLength[length].length),
+}));
+---
+
+<Layout title={title} description={description}>
+  <main class="main__content lengths">
+    <Heading text={title} />
+    <ul>
+      {lengthLinks.map(({ length, countText }) => (
+        <li class="lengths__item">
+          <SiteLink href={`/words/length/${length}`}>
+            {length}-letter words ({countText})
+          </SiteLink>
+        </li>
+      ))}
+    </ul>
+  </main>
+</Layout>
+
+<style>
+  .lengths {
+    max-width: var(--content-width-small);
+  }
+
+  .lengths__item {
+    margin-bottom: var(--spacing-base);
+  }
+</style>
+

--- a/src/utils/word-data-utils.ts
+++ b/src/utils/word-data-utils.ts
@@ -4,6 +4,7 @@ import { getAdapter } from '~adapters';
 import type {
   WordAdjacentResult,
   WordData,
+  WordGroupByLengthResult,
   WordGroupByYearResult,
   WordProcessedData,
 } from '~types/word';
@@ -219,6 +220,22 @@ export const groupWordsByYear = (words: WordData[]): WordGroupByYearResult => {
 };
 
 /**
+ * Groups an array of word data by length.
+ * Creates an object where keys are word lengths and values are arrays of words from that length.
+ *
+ * @param {WordData[]} words - Array of word data to group by length
+ * @returns {WordGroupByLengthResult} Object with lengths as keys and word arrays as values
+ */
+export const groupWordsByLength = (words: WordData[]): WordGroupByLengthResult => {
+  return words.reduce<WordGroupByLengthResult>((acc, word) => {
+    const length = word.word.length;
+    acc[length] = acc[length] || [];
+    acc[length].push(word);
+    return acc;
+  }, {});
+};
+
+/**
  * Retrieves a list of all years that have word data available.
  * Returns years in descending order (newest first) for UI display purposes.
  *
@@ -228,5 +245,28 @@ export const groupWordsByYear = (words: WordData[]): WordGroupByYearResult => {
 export const getAvailableYears = (words: WordData[] = allWords): string[] => {
   const years = [...new Set(words.map(word => word.date.substring(0, 4)))];
   return years.sort((a, b) => b.localeCompare(a));
+};
+
+/**
+ * Retrieves all words that match a specific length.
+ *
+ * @param {number} length - Word length to filter by
+ * @param {WordData[]} [words=allWords] - Array of word data to search through
+ * @returns {WordData[]} Array of word data entries with the specified length
+ */
+export const getWordsByLength = (length: number, words: WordData[] = allWords): WordData[] => {
+  return words.filter(word => word.word.length === length);
+};
+
+/**
+ * Retrieves a list of all unique word lengths available.
+ * Returns lengths in ascending order for UI display.
+ *
+ * @param {WordData[]} [words=allWords] - Array of word data to search through
+ * @returns {number[]} Array of unique word lengths sorted in ascending order
+ */
+export const getAvailableLengths = (words: WordData[] = allWords): number[] => {
+  const lengths = [...new Set(words.map(word => word.word.length))];
+  return lengths.sort((a, b) => a - b);
 };
 

--- a/tests/utils/word-length-utils.spec.js
+++ b/tests/utils/word-length-utils.spec.js
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { getAvailableLengths, getWordsByLength, groupWordsByLength } from '~utils-client/word-data-utils';
+
+describe('word length utilities', () => {
+  it('returns unique lengths from all words', () => {
+    const lengths = getAvailableLengths();
+    expect(lengths).toEqual([4, 10, 11]);
+  });
+
+  it('filters words by specified length', () => {
+    const words = getWordsByLength(10);
+    expect(words).toHaveLength(1);
+    expect(words[0].word).toBe('occasional');
+  });
+
+  it('groups words by length', () => {
+    const words = global.mockWordData.map(entry => entry.data);
+    const groups = groupWordsByLength(words);
+    expect(Object.keys(groups).map(Number).sort((a, b) => a - b)).toEqual([4, 10, 11]);
+  });
+});
+

--- a/types/word.ts
+++ b/types/word.ts
@@ -75,6 +75,10 @@ export interface WordGroupByYearResult {
   [year: string]: WordData[];
 }
 
+export interface WordGroupByLengthResult {
+  [length: number]: WordData[];
+}
+
 export interface WordFileGlobImport {
   [path: string]: WordData | WordData[];
 }


### PR DESCRIPTION
## Summary
- add utilities to group and filter words by length
- create index and detail pages for browsing words by length
- test length utilities for multiple word sizes

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893735e29cc832a87f7d7e867b4c575