### PR TITLE
feat: add monthly word archives

### DIFF
--- a/src/components/StatsWordListPage.astro
+++ b/src/components/StatsWordListPage.astro
@@ -26,9 +26,9 @@ const { title, description } = getPageMetadata(Astro.url.pathname);
   <main class="words">
     <Heading text={title} secondaryText={formatWordCount(words.length)} />
     <DescriptionText text={descriptionText} />
-    <section class="words__section">
+    <div class="words__content">
       <WordList words={words} columns={columns} />
-    </section>
+    </div>
   </main>
 </Layout>
 
@@ -38,7 +38,4 @@ const { title, description } = getPageMetadata(Astro.url.pathname);
     margin: 0 auto;
   }
 
-  .words__section {
-    margin-bottom: var(--spacing-large);
-  }
 </style>

--- a/src/components/WordSection.astro
+++ b/src/components/WordSection.astro
@@ -1,0 +1,25 @@
+---
+import SectionHeading from '~components/SectionHeading.astro';
+import WordList from '~components/WordList.astro';
+import type { WordData } from '~types/word';
+
+interface Props {
+  title: string;
+  href?: string;
+  words: WordData[];
+  columns?: number;
+}
+
+const { title, href, words, columns = 2 } = Astro.props;
+---
+
+<section class="word-section">
+  <SectionHeading text={title} href={href} />
+  <WordList words={words} columns={columns} />
+</section>
+
+<style>
+  .word-section {
+    margin-bottom: var(--spacing-large);
+  }
+</style>

--- a/src/pages/words/[year]/[month].astro
+++ b/src/pages/words/[year]/[month].astro
@@ -39,7 +39,7 @@ const monthName = format(new Date(Number(year), Number(month) - 1), 'MMMM');
 
 <Layout title={title} description={description} structuredDataType={STRUCTURED_DATA_TYPE.WORD_LIST}>
   <main class="month-words">
-    <Heading level={1} text={`${monthName} ${year}`} secondaryText="Words in" />
+    <Heading level={1} text={monthName} secondaryText={year} />
     <div class="month-words__content">
       <WordList words={words} columns={2} />
     </div>

--- a/src/pages/words/[year]/[month].astro
+++ b/src/pages/words/[year]/[month].astro
@@ -1,0 +1,58 @@
+---
+import { format } from 'date-fns';
+
+import Heading from '~components/Heading.astro';
+import WordList from '~components/WordList.astro';
+import Layout from '~layouts/Layout.astro';
+import { getPageMetadata } from '~utils-client/page-metadata.ts';
+import { STRUCTURED_DATA_TYPE } from '~utils-client/schema-utils.ts';
+import {
+  getAvailableMonths,
+  getAvailableYears,
+  getWordsByMonth,
+  getWordsFromCollection,
+} from '~utils-client/word-data-utils';
+
+export async function getStaticPaths() {
+  const allWords = await getWordsFromCollection();
+  const years = getAvailableYears(allWords);
+  const paths = [];
+
+  years.forEach(year => {
+    const months = getAvailableMonths(year, allWords);
+    months.forEach(month => {
+      paths.push({
+        params: { year, month },
+        props: { words: getWordsByMonth(year, month, allWords) },
+      });
+    });
+  });
+
+  return paths;
+}
+
+const { year, month } = Astro.params;
+const { words } = Astro.props;
+const { title, description } = getPageMetadata(Astro.url.pathname);
+const monthName = format(new Date(Number(year), Number(month) - 1), 'MMMM');
+---
+
+<Layout title={title} description={description} structuredDataType={STRUCTURED_DATA_TYPE.WORD_LIST}>
+  <main class="month-words">
+    <Heading level={1} text={`${monthName} ${year}`} secondaryText="Words in" />
+    <div class="month-words__content">
+      <WordList words={words} columns={2} />
+    </div>
+  </main>
+</Layout>
+
+<style>
+    .month-words {
+        max-width: var(--content-width-medium);
+        margin: 0 auto;
+    }
+
+    .month-words__content {
+        width: 100%;
+    }
+</style>

--- a/src/pages/words/[year]/[month].astro
+++ b/src/pages/words/[year]/[month].astro
@@ -1,16 +1,14 @@
 ---
-import { format } from 'date-fns';
-
 import Heading from '~components/Heading.astro';
-import WordList from '~components/WordList.astro';
+import WordSection from '~components/WordSection.astro';
 import Layout from '~layouts/Layout.astro';
+import { getMonthNameFromDate } from '~utils/date-utils';
 import { getPageMetadata } from '~utils-client/page-metadata.ts';
 import { STRUCTURED_DATA_TYPE } from '~utils-client/schema-utils.ts';
 import {
-  getAvailableMonths,
   getAvailableYears,
-  getWordsByMonth,
   getWordsFromCollection,
+  groupWordsByMonth,
 } from '~utils-client/word-data-utils';
 
 export async function getStaticPaths() {
@@ -19,11 +17,11 @@ export async function getStaticPaths() {
   const paths = [];
 
   years.forEach(year => {
-    const months = getAvailableMonths(year, allWords);
-    months.forEach(month => {
+    const monthGroups = groupWordsByMonth(year, allWords);
+    Object.entries(monthGroups).forEach(([monthSlug, words]) => {
       paths.push({
-        params: { year, month },
-        props: { words: getWordsByMonth(year, month, allWords) },
+        params: { year, month: monthSlug },
+        props: { words },
       });
     });
   });
@@ -31,28 +29,22 @@ export async function getStaticPaths() {
   return paths;
 }
 
-const { year, month } = Astro.params;
+const { year } = Astro.params;
 const { words } = Astro.props;
 const { title, description } = getPageMetadata(Astro.url.pathname);
-const monthName = format(new Date(Number(year), Number(month) - 1), 'MMMM');
+const monthName = getMonthNameFromDate(words[0].date);
 ---
 
 <Layout title={title} description={description} structuredDataType={STRUCTURED_DATA_TYPE.WORD_LIST}>
-  <main class="month-words">
+  <main class="words">
     <Heading level={1} text={monthName} secondaryText={year} />
-    <div class="month-words__content">
-      <WordList words={words} columns={2} />
-    </div>
+    <WordSection title="" words={words} />
   </main>
 </Layout>
 
 <style>
-    .month-words {
+    .words {
         max-width: var(--content-width-medium);
         margin: 0 auto;
-    }
-
-    .month-words__content {
-        width: 100%;
     }
 </style>

--- a/src/pages/words/[year]/index.astro
+++ b/src/pages/words/[year]/index.astro
@@ -2,8 +2,7 @@
 import { format } from 'date-fns';
 
 import Heading from '~components/Heading.astro';
-import SiteLink from '~components/SiteLink.astro';
-import WordList from '~components/WordList.astro';
+import WordSection from '~components/WordSection.astro';
 import Layout from '~layouts/Layout.astro';
 import { getPageMetadata } from '~utils-client/page-metadata.ts';
 import { STRUCTURED_DATA_TYPE } from '~utils-client/schema-utils.ts';
@@ -37,18 +36,16 @@ const months = getAvailableMonths(year, words);
 <Layout title={title} description={description} structuredDataType={STRUCTURED_DATA_TYPE.WORD_LIST}>
   <main class="year-words">
     <Heading level={1} text={year} secondaryText="Words in" />
-    <ul class="year-words__months">
-      {months.map(month => (
-        <li>
-          <SiteLink href={`/words/${year}/${month}`}>
-            {format(new Date(Number(year), Number(month) - 1), 'MMMM')}
-          </SiteLink>
-        </li>
-      ))}
-    </ul>
-    <div class="year-words__content">
-      <WordList words={words} columns={2} />
-    </div>
+    {months.map(month => {
+      const monthWords = words.filter(word => word.date.substring(4, 6) === month);
+      return (
+        <WordSection
+          title={format(new Date(Number(year), Number(month) - 1), 'MMMM')}
+          href={`/words/${year}/${month}`}
+          words={monthWords}
+        />
+      );
+    })}
   </main>
 </Layout>
 
@@ -58,18 +55,6 @@ const months = getAvailableMonths(year, words);
         margin: 0 auto;
     }
 
-    .year-words__months {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.5rem;
-        list-style: none;
-        padding: 0;
-        margin: var(--spacing-medium) 0;
-    }
-
-    .year-words__months li {
-        margin: 0;
-    }
 
     .year-words__content {
         width: 100%;

--- a/src/pages/words/[year]/index.astro
+++ b/src/pages/words/[year]/index.astro
@@ -1,16 +1,16 @@
 ---
-import { format } from 'date-fns';
 
 import Heading from '~components/Heading.astro';
 import WordSection from '~components/WordSection.astro';
 import Layout from '~layouts/Layout.astro';
+import { getMonthNameFromDate } from '~utils/date-utils';
 import { getPageMetadata } from '~utils-client/page-metadata.ts';
 import { STRUCTURED_DATA_TYPE } from '~utils-client/schema-utils.ts';
 import {
-  getAvailableMonths,
   getAvailableYears,
   getWordsByYear,
   getWordsFromCollection,
+  groupWordsByMonth,
 } from '~utils-client/word-data-utils';
 
 const { title, description } = getPageMetadata(Astro.url.pathname);
@@ -30,22 +30,19 @@ export async function getStaticPaths() {
 
 const { year } = Astro.params;
 const { words } = Astro.props;
-const months = getAvailableMonths(year, words);
+const monthGroups = groupWordsByMonth(year, words);
 ---
 
 <Layout title={title} description={description} structuredDataType={STRUCTURED_DATA_TYPE.WORD_LIST}>
   <main class="year-words">
     <Heading level={1} text={year} secondaryText="Words in" />
-    {months.map(month => {
-      const monthWords = words.filter(word => word.date.substring(4, 6) === month);
-      return (
-        <WordSection
-          title={format(new Date(Number(year), Number(month) - 1), 'MMMM')}
-          href={`/words/${year}/${month}`}
-          words={monthWords}
-        />
-      );
-    })}
+    {Object.entries(monthGroups).map(([monthSlug, monthWords]) => (
+      <WordSection
+        title={getMonthNameFromDate(monthWords[0].date)}
+        href={`/words/${year}/${monthSlug}`}
+        words={monthWords}
+      />
+    ))}
   </main>
 </Layout>
 

--- a/src/pages/words/[year]/index.astro
+++ b/src/pages/words/[year]/index.astro
@@ -1,33 +1,51 @@
 ---
+import { format } from 'date-fns';
+
 import Heading from '~components/Heading.astro';
+import SiteLink from '~components/SiteLink.astro';
 import WordList from '~components/WordList.astro';
 import Layout from '~layouts/Layout.astro';
 import { getPageMetadata } from '~utils-client/page-metadata.ts';
 import { STRUCTURED_DATA_TYPE } from '~utils-client/schema-utils.ts';
-import { getWordsFromCollection } from '~utils-client/word-data-utils';
+import {
+  getAvailableMonths,
+  getAvailableYears,
+  getWordsByYear,
+  getWordsFromCollection,
+} from '~utils-client/word-data-utils';
+
 const { title, description } = getPageMetadata(Astro.url.pathname);
 
 export async function getStaticPaths() {
   const allWords = await getWordsFromCollection();
 
-  const years = [...new Set(allWords.map(word => word.date.substring(0, 4)))]
-    .sort((a, b) => b.localeCompare(a));
+  const years = getAvailableYears(allWords);
 
   return years
     .map(year => ({
       params: { year },
-      props: { words: allWords.filter(word => word.date.startsWith(year)) },
+      props: { words: getWordsByYear(year, allWords) },
     }))
     .filter(({ props }) => props.words.length > 0);
 }
 
 const { year } = Astro.params;
 const { words } = Astro.props;
+const months = getAvailableMonths(year, words);
 ---
 
 <Layout title={title} description={description} structuredDataType={STRUCTURED_DATA_TYPE.WORD_LIST}>
   <main class="year-words">
     <Heading level={1} text={year} secondaryText="Words in" />
+    <ul class="year-words__months">
+      {months.map(month => (
+        <li>
+          <SiteLink href={`/words/${year}/${month}`}>
+            {format(new Date(Number(year), Number(month) - 1), 'MMMM')}
+          </SiteLink>
+        </li>
+      ))}
+    </ul>
     <div class="year-words__content">
       <WordList words={words} columns={2} />
     </div>
@@ -38,6 +56,19 @@ const { words } = Astro.props;
     .year-words {
         max-width: var(--content-width-medium);
         margin: 0 auto;
+    }
+
+    .year-words__months {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        list-style: none;
+        padding: 0;
+        margin: var(--spacing-medium) 0;
+    }
+
+    .year-words__months li {
+        margin: 0;
     }
 
     .year-words__content {

--- a/src/pages/words/index.astro
+++ b/src/pages/words/index.astro
@@ -1,7 +1,6 @@
 ---
 import Heading from '~components/Heading.astro';
-import SectionHeading from '~components/SectionHeading.astro';
-import WordList from '~components/WordList.astro';
+import WordSection from '~components/WordSection.astro';
 import Layout from '~layouts/Layout.astro';
 import { getPageMetadata } from '~utils-client/page-metadata.ts';
 import { STRUCTURED_DATA_TYPE } from '~utils-client/schema-utils.ts';
@@ -17,10 +16,7 @@ const { title, description } = getPageMetadata(Astro.url.pathname);
   <main class="words">
     <Heading text={title} secondaryText={formatWordCount(allWords.length)} />
     {(Object.entries(wordsByYear) as [string, typeof allWords][]).reverse().map(([year, words]) => (
-      <section class="words__section">
-        <SectionHeading text={year} href={`/words/${year}`} />
-        <WordList words={words} columns={2} />
-      </section>
+      <WordSection title={year} href={`/words/${year}`} words={words} />
     ))}
   </main>
 </Layout>
@@ -31,7 +27,4 @@ const { title, description } = getPageMetadata(Astro.url.pathname);
         margin: 0 auto;
     }
 
-    .words__section {
-        margin-bottom: var(--spacing-large);
-    }
 </style>

--- a/src/utils/page-metadata.ts
+++ b/src/utils/page-metadata.ts
@@ -1,3 +1,5 @@
+import { format } from 'date-fns';
+
 import type { WordData } from '~types/word';
 import { logger } from '~utils-client/logger';
 import {
@@ -263,7 +265,15 @@ throw new Error('getPageMetadata: pathname is required. Pass Astro.url.pathname 
   const path = pathname.replace(/^\//, '').replace(/\/$/, '');
 
   if (path.startsWith('words/') && path !== 'words') {
-    const year = path.replace('words/', '');
+    const [year, month] = path.replace('words/', '').split('/');
+    if (year && month) {
+      const monthName = format(new Date(Number(year), Number(month) - 1), 'MMMM');
+      return {
+        title: `${monthName} ${year} words`,
+        description: `Words featured during ${monthName} ${year}.`,
+        category: 'pages' as const,
+      };
+    }
     return {
       title: `${year} words`,
       description: `Words featured during ${year}.`,

--- a/src/utils/page-metadata.ts
+++ b/src/utils/page-metadata.ts
@@ -1,6 +1,7 @@
 import { format } from 'date-fns';
 
 import type { WordData } from '~types/word';
+import { monthSlugToNumber } from '~utils/date-utils';
 import { logger } from '~utils-client/logger';
 import {
   DYNAMIC_STATS_DEFINITIONS,
@@ -267,12 +268,15 @@ throw new Error('getPageMetadata: pathname is required. Pass Astro.url.pathname 
   if (path.startsWith('words/') && path !== 'words') {
     const [year, month] = path.replace('words/', '').split('/');
     if (year && month) {
-      const monthName = format(new Date(Number(year), Number(month) - 1), 'MMMM');
-      return {
-        title: `${monthName} ${year} words`,
-        description: `Words featured during ${monthName} ${year}.`,
-        category: 'pages' as const,
-      };
+      const monthNumber = monthSlugToNumber(month);
+      if (monthNumber) {
+        const monthName = format(new Date(Number(year), monthNumber - 1), 'MMMM');
+        return {
+          title: `${monthName} ${year} words`,
+          description: `Words featured during ${monthName} ${year}.`,
+          category: 'pages' as const,
+        };
+      }
     }
     return {
       title: `${year} words`,

--- a/src/utils/word-data-utils.ts
+++ b/src/utils/word-data-utils.ts
@@ -189,6 +189,44 @@ export const getWordsByYear = (year: string, words: WordData[] = allWords): Word
 };
 
 /**
+ * Retrieves all words that occurred within a specific month of a given year.
+ * Useful for generating monthly archives.
+ *
+ * @param {string} year - Year to filter by (YYYY format)
+ * @param {string} month - Month to filter by (MM format)
+ * @param {WordData[]} [words=allWords] - Array of word data to search through
+ * @returns {WordData[]} Array of word data entries from the specified month and year
+ */
+export const getWordsByMonth = (
+  year: string,
+  month: string,
+  words: WordData[] = allWords,
+): WordData[] => {
+  const monthStr = month.padStart(2, '0');
+  return words.filter(word => word.date.startsWith(`${year}${monthStr}`));
+};
+
+/**
+ * Retrieves a list of all months that have word data for a given year.
+ * Returns months in ascending order for UI display purposes.
+ *
+ * @param {string} year - Year to filter by (YYYY format)
+ * @param {WordData[]} [words=allWords] - Array of word data to search through
+ * @returns {string[]} Array of unique months (MM format) sorted in ascending order
+ */
+export const getAvailableMonths = (
+  year: string,
+  words: WordData[] = allWords,
+): string[] => {
+  const months = new Set(
+    words
+      .filter(word => word.date.startsWith(year))
+      .map(word => word.date.substring(4, 6)),
+  );
+  return [...months].sort((a, b) => a.localeCompare(b));
+};
+
+/**
  * Generates a SHA-256 hash from a list of words and their count.
  * Useful for creating cache keys or detecting changes in word datasets.
  * Words are sorted alphabetically before hashing to ensure consistent results.

--- a/src/utils/word-data-utils.ts
+++ b/src/utils/word-data-utils.ts
@@ -7,6 +7,7 @@ import type {
   WordGroupByYearResult,
   WordProcessedData,
 } from '~types/word';
+import { getMonthSlugFromDate } from '~utils/date-utils';
 import { logger } from '~utils-client/logger';
 
 /**
@@ -224,6 +225,25 @@ export const getAvailableMonths = (
       .map(word => word.date.substring(4, 6)),
   );
   return [...months].sort((a, b) => a.localeCompare(b));
+};
+
+/**
+ * Groups words by month within a specific year.
+ * Returns an object with month slugs as keys and word arrays as values.
+ *
+ * @param {string} year - Year to filter by (YYYY format)
+ * @param {WordData[]} [words=allWords] - Array of word data to group
+ * @returns {Object} Object with month slugs as keys and word arrays as values
+ */
+export const groupWordsByMonth = (year: string, words: WordData[] = allWords): { [monthSlug: string]: WordData[] } => {
+  return words
+    .filter(word => word.date.startsWith(year))
+    .reduce((acc, word) => {
+      const monthSlug = getMonthSlugFromDate(word.date);
+      acc[monthSlug] = acc[monthSlug] || [];
+      acc[monthSlug].push(word);
+      return acc;
+    }, {} as { [monthSlug: string]: WordData[] });
 };
 
 /**

--- a/tests/utils/date-utils.spec.js
+++ b/tests/utils/date-utils.spec.js
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
- dateToYYYYMMDD, formatDate, getTodayYYYYMMDD, isValidDate, YYYYMMDDToDate,
+ dateToYYYYMMDD, formatDate, getMonthNameFromDate, getMonthSlugFromDate, getTodayYYYYMMDD, isValidDate, MONTH_NAMES, monthSlugToNumber, YYYYMMDDToDate,
 } from '~utils/date-utils';
 
 describe('shared date-utils', () => {
@@ -121,6 +121,65 @@ describe('shared date-utils', () => {
       expect(result).toBeInstanceOf(Date);
       expect(result?.getMonth()).toBe(1); // February
       expect(result?.getDate()).toBe(29);
+    });
+  });
+
+  describe('getMonthNameFromDate', () => {
+    it('extracts month name from YYYYMMDD date string', () => {
+      expect(getMonthNameFromDate('20250115')).toBe('January');
+      expect(getMonthNameFromDate('20250628')).toBe('June');
+      expect(getMonthNameFromDate('20251225')).toBe('December');
+    });
+
+    it('returns "Invalid Month" for invalid date strings', () => {
+      expect(getMonthNameFromDate('invalid')).toBe('Invalid Month');
+      expect(getMonthNameFromDate('20251301')).toBe('Invalid Month'); // Invalid month
+    });
+  });
+
+  describe('getMonthSlugFromDate', () => {
+    it('extracts lowercase month name from YYYYMMDD date string', () => {
+      expect(getMonthSlugFromDate('20250115')).toBe('january');
+      expect(getMonthSlugFromDate('20250628')).toBe('june');
+      expect(getMonthSlugFromDate('20251225')).toBe('december');
+    });
+
+    it('returns "invalid month" for invalid date strings', () => {
+      expect(getMonthSlugFromDate('invalid')).toBe('invalid month');
+      expect(getMonthSlugFromDate('20251301')).toBe('invalid month');
+    });
+  });
+
+  describe('monthSlugToNumber', () => {
+    it('converts month slug to month number', () => {
+      expect(monthSlugToNumber('january')).toBe(1);
+      expect(monthSlugToNumber('june')).toBe(6);
+      expect(monthSlugToNumber('december')).toBe(12);
+    });
+
+    it('handles case insensitive input', () => {
+      expect(monthSlugToNumber('JANUARY')).toBe(1);
+      expect(monthSlugToNumber('June')).toBe(6);
+      expect(monthSlugToNumber('DeCeMbEr')).toBe(12);
+    });
+
+    it('returns null for invalid month slugs', () => {
+      expect(monthSlugToNumber('invalid')).toBe(null);
+      expect(monthSlugToNumber('month13')).toBe(null);
+      expect(monthSlugToNumber('')).toBe(null);
+    });
+  });
+
+  describe('MONTH_NAMES', () => {
+    it('contains all 12 months in lowercase', () => {
+      expect(MONTH_NAMES).toHaveLength(12);
+      expect(MONTH_NAMES[0]).toBe('january');
+      expect(MONTH_NAMES[11]).toBe('december');
+    });
+
+    it('contains expected month names in order', () => {
+      const expected = ['january', 'february', 'march', 'april', 'may', 'june', 'july', 'august', 'september', 'october', 'november', 'december'];
+      expect(MONTH_NAMES).toEqual(expected);
     });
   });
 });

--- a/tests/utils/page-metadata.spec.js
+++ b/tests/utils/page-metadata.spec.js
@@ -40,7 +40,7 @@ describe('page-metadata', () => {
     });
 
     it('returns metadata for dynamic month pages', () => {
-      const metadata = getPageMetadata('words/2024/12');
+      const metadata = getPageMetadata('words/2024/december');
       expect(metadata).toEqual({
         title: 'December 2024 words',
         description: 'Words featured during December 2024.',

--- a/tests/utils/page-metadata.spec.js
+++ b/tests/utils/page-metadata.spec.js
@@ -39,6 +39,15 @@ describe('page-metadata', () => {
       });
     });
 
+    it('returns metadata for dynamic month pages', () => {
+      const metadata = getPageMetadata('words/2024/12');
+      expect(metadata).toEqual({
+        title: 'December 2024 words',
+        description: 'Words featured during December 2024.',
+        category: 'pages',
+      });
+    });
+
     it('returns fallback metadata for unknown paths', () => {
       const metadata = getPageMetadata('unknown-path');
       expect(metadata).toEqual({

--- a/tests/utils/word-data-utils.spec.js
+++ b/tests/utils/word-data-utils.spec.js
@@ -13,6 +13,7 @@ import {
   getWordDetails,
   getWordsByMonth,
   getWordsByYear,
+  groupWordsByMonth,
   groupWordsByYear,
 } from '~utils-client/word-data-utils';
 
@@ -244,6 +245,32 @@ describe('word-data-utils', () => {
     it('handles empty array', () => {
       const result = groupWordsByYear([]);
       expect(result).toEqual({});
+    });
+  });
+
+  describe('groupWordsByMonth', () => {
+    it('groups words by month slug for a given year', () => {
+      const result = groupWordsByMonth('2025', mockWordData);
+      expect(Object.keys(result)).toContain('january');
+      expect(result['january']).toHaveLength(3);
+    });
+
+    it('returns empty object when no words match the year', () => {
+      const result = groupWordsByMonth('2020', mockWordData);
+      expect(result).toEqual({});
+    });
+
+    it('groups words with different months correctly', () => {
+      const extendedData = [...mockWordData, { word: 'feb', date: '20250201', data: [] }];
+      const result = groupWordsByMonth('2025', extendedData);
+      expect(Object.keys(result)).toEqual(expect.arrayContaining(['january', 'february']));
+      expect(result['january']).toHaveLength(3);
+      expect(result['february']).toHaveLength(1);
+    });
+
+    it('uses month slugs as keys', () => {
+      const result = groupWordsByMonth('2025', mockWordData);
+      expect(Object.keys(result)).toEqual(['january']); // lowercase month name
     });
   });
 

--- a/tests/utils/word-data-utils.spec.js
+++ b/tests/utils/word-data-utils.spec.js
@@ -5,11 +5,13 @@ import {
 import { isValidDictionaryData } from '~utils/word-validation';
 import {
   getAdjacentWords,
+  getAvailableMonths,
   getAvailableYears,
   getCurrentWord,
   getPastWords,
   getWordByDate,
   getWordDetails,
+  getWordsByMonth,
   getWordsByYear,
   groupWordsByYear,
 } from '~utils-client/word-data-utils';
@@ -194,6 +196,39 @@ describe('word-data-utils', () => {
 
     it('returns empty array for non-existent year', () => {
       const result = getWordsByYear('2020', mockWordData);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getWordsByMonth', () => {
+    it('filters words by month within a year', () => {
+      const result = getWordsByMonth('2025', '01', mockWordData);
+      expect(result).toHaveLength(3);
+      expect(result.every(w => w.date.startsWith('202501'))).toBe(true);
+
+      const result2024 = getWordsByMonth('2024', '12', mockWordData);
+      expect(result2024).toHaveLength(1);
+      expect(result2024[0].word).toBe('year2024');
+    });
+
+    it('returns empty array for non-existent month', () => {
+      const result = getWordsByMonth('2025', '02', mockWordData);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getAvailableMonths', () => {
+    it('returns unique months for a year in ascending order', () => {
+      const extended = [...mockWordData, { word: 'feb', date: '20250201', data: [] }];
+      const result = getAvailableMonths('2025', extended);
+      expect(result).toEqual(['01', '02']);
+
+      const result2024 = getAvailableMonths('2024', mockWordData);
+      expect(result2024).toEqual(['12']);
+    });
+
+    it('returns empty array for year with no words', () => {
+      const result = getAvailableMonths('2020', mockWordData);
       expect(result).toEqual([]);
     });
   });

--- a/utils/date-utils.ts
+++ b/utils/date-utils.ts
@@ -1,6 +1,14 @@
 import { format, isValid, parse, startOfDay } from 'date-fns';
 
 /**
+ * Shared month names constant for consistent usage across the application
+ */
+export const MONTH_NAMES = [
+  'january', 'february', 'march', 'april', 'may', 'june',
+  'july', 'august', 'september', 'october', 'november', 'december',
+] as const;
+
+/**
  * Validates if a date string is in correct YYYYMMDD format
  */
 export const isValidDate = (dateStr: string): boolean => {
@@ -47,4 +55,30 @@ export const YYYYMMDDToDate = (dateStr: string): Date | null => {
     return null;
   }
   return startOfDay(date);
+};
+
+/**
+ * Extracts month name from YYYYMMDD date string
+ */
+export const getMonthNameFromDate = (dateStr: string): string => {
+  const date = YYYYMMDDToDate(dateStr);
+  if (!date) {
+    return 'Invalid Month';
+  }
+  return format(date, 'MMMM');
+};
+
+/**
+ * Extracts lowercase month name from YYYYMMDD date string for URLs
+ */
+export const getMonthSlugFromDate = (dateStr: string): string => {
+  return getMonthNameFromDate(dateStr).toLowerCase();
+};
+
+/**
+ * Converts month slug back to month number (1-12)
+ */
+export const monthSlugToNumber = (monthSlug: string): number | null => {
+  const index = MONTH_NAMES.indexOf(monthSlug.toLowerCase() as typeof MONTH_NAMES[number]);
+  return index >= 0 ? index + 1 : null;
 };


### PR DESCRIPTION
## Summary
- add `/words/[year]/[month]` route for month-based word archives
- link year pages to available months
- support month filtering utilities and metadata

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `SITE_URL=https://example.com SITE_TITLE=test SITE_DESCRIPTION=desc SITE_ID=test npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893735a48a4832a9502622622f09aa4