### PR TITLE
feat: show cat photos for word of the day

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,9 @@ WORDNIK_API_KEY=
 WORDNIK_API_URL=https://api.wordnik.com/v4
 WORDNIK_WEBSITE_URL=https://www.wordnik.com
 
+# Cat image service
+CAT_IMAGE_BASE_URL=https://cataas.com/cat/says
+
 # Data Source
 # Data directory (demo, words, etc.)
 SOURCE_DIR="demo"

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ A template for creating family word-of-the-day sites that provides a foundation 
 - **Rich Word Data**: Powered by Wordnik API with comprehensive definitions
 - **Smart Statistics**: Letter patterns, word endings, reading streaks, and linguistic analysis
 - **Social Images**: Automated generation of beautiful, shareable word graphics
+- **Cat Companions**: Each word is paired with a delightful cat photo
 - **Lightning Fast**: Static site generation with Astro for optimal performance
 - **Customizable**: Environment-based theming and multi-source data support
 - **Accessible**: WCAG compliant with keyboard navigation and screen reader support
@@ -76,6 +77,9 @@ SOURCE_DIR="words"                      # Data source (demo, words, etc.)
 # Dictionary Service
 DICTIONARY_ADAPTER="wordnik"
 WORDNIK_API_KEY="your-api-key-here"
+
+# Cat Images
+CAT_IMAGE_BASE_URL="https://cataas.com/cat/says"
 
 # Colors (optional)
 COLOR_PRIMARY="#b45309"

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -84,6 +84,11 @@ SOURCE_DIR                  # Data source directory (default: "demo")
 DICTIONARY_ADAPTER          # Dictionary service (default: "wordnik")
 ```
 
+### Cat Image Service
+```bash
+CAT_IMAGE_BASE_URL         # Base URL for cat images (default: https://cataas.com/cat/says)
+```
+
 ### Color Customization
 ```bash
 COLOR_PRIMARY               # Primary brand color

--- a/src/components/Word.astro
+++ b/src/components/Word.astro
@@ -3,6 +3,7 @@ import Heading from '~components/Heading.astro';
 import WordDescription from '~components/WordDescription.astro';
 import type { WordData } from '~types/word';
 import { formatDate } from '~utils/date-utils';
+import { getCatImageUrl } from '~utils-client/image-utils';
 import { getWordDetails } from '~utils-client/word-data-utils';
 
 interface Props {
@@ -17,6 +18,7 @@ if (!word) {
 }
 
 const { partOfSpeech, definition, meta } = getWordDetails(word);
+const catImageUrl = getCatImageUrl(word.word);
 ---
 
 <article class="word">
@@ -26,6 +28,11 @@ const { partOfSpeech, definition, meta } = getWordDetails(word);
     partOfSpeech={partOfSpeech}
     definition={definition}
     meta={meta}
+  />
+  <img
+    src={catImageUrl}
+    alt={`A cat related to the word ${word.word}`}
+    class="word__cat-image"
   />
 </article>
 
@@ -42,7 +49,14 @@ const { partOfSpeech, definition, meta } = getWordDetails(word);
         display: block;
         font-size: var(--font-size-xs, 0.75rem);
         color: var(--color-text-light);
-        margin-bottom: var(--spacing-small);
-    }
+      margin-bottom: var(--spacing-small);
+      }
+
+      .word__cat-image {
+          width: 100%;
+          max-width: 400px;
+          height: auto;
+          margin-top: var(--spacing-large);
+      }
 
 </style>

--- a/src/utils/image-utils.ts
+++ b/src/utils/image-utils.ts
@@ -32,3 +32,13 @@ export async function getStaticPages() {
   const { getAllPageMetadata } = await import('~utils-client/page-metadata');
   return getAllPageMetadata();
 }
+
+/**
+ * Get cat image URL for a word
+ * @param word - Word of the day
+ * @returns URL to the cat image
+ */
+export function getCatImageUrl(word: string): string {
+  const baseUrl = (import.meta.env.CAT_IMAGE_BASE_URL || 'https://cataas.com/cat/says').replace(/\/$/, '');
+  return `${baseUrl}/${encodeURIComponent(word)}`;
+}

--- a/tests/utils/image-utils.spec.js
+++ b/tests/utils/image-utils.spec.js
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { getCatImageUrl } from '~utils-client/image-utils';
+
+describe('utils', () => {
+  describe('getCatImageUrl', () => {
+    it('returns default cat image url', () => {
+      vi.stubEnv('CAT_IMAGE_BASE_URL', '');
+      expect(getCatImageUrl('hello world')).toBe('https://cataas.com/cat/says/hello%20world');
+    });
+
+    it('uses custom base url from environment', () => {
+      vi.stubEnv('CAT_IMAGE_BASE_URL', 'https://example.com/cat');
+      expect(getCatImageUrl('test')).toBe('https://example.com/cat/test');
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- display a cat image alongside each day's word
- generate cat image URLs via configurable base URL
- document new CAT_IMAGE_BASE_URL environment variable and add tests

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `SITE_URL=https://example.com SITE_TITLE="Occasional WOTD" SITE_DESCRIPTION="Educational" SITE_ID=owotd npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894c2a0cbe8832a99ffc860ef7ff2f2