### PR TITLE
Fix page metadata base path handling

### DIFF
--- a/src/utils/page-metadata.ts
+++ b/src/utils/page-metadata.ts
@@ -308,7 +308,11 @@ export function getPageMetadata(pathname?: string, words: WordData[] = allWords)
   if (!pathname) {
 throw new Error('getPageMetadata: pathname is required. Pass Astro.url.pathname from your page.');
 }
-  const path = pathname.replace(/^\//, '').replace(/\/$/, '');
+    let path = pathname.replace(/^\//, '').replace(/\/$/, '');
+    const basePath = import.meta.env.BASE_PATH?.replace(/^\/|\/$/g, '') || '';
+    if (basePath && (path === basePath || path.startsWith(`${basePath}/`))) {
+      path = path.slice(basePath.length).replace(/^\//, '');
+    }
 
   if (path.startsWith('words/length/') && path !== 'words/length') {
     const lengthStr = path.replace('words/length/', '');

--- a/tests/src/components/WordLink.spec.js
+++ b/tests/src/components/WordLink.spec.js
@@ -32,20 +32,20 @@ describe('WordLink Component Integration', () => {
   describe('WordLink + SiteLink integration flow', () => {
     it('should prevent double BASE_PATH with no subdirectory', () => {
       vi.stubEnv('BASE_PATH', '/');
-      
+
       const rawPath = getWordUrl('serendipity');
       const processedUrl = getUrl(rawPath);
-      
+
       expect(rawPath).toBe('/words/serendipity');
       expect(processedUrl).toBe('/words/serendipity');
     });
 
     it('should prevent double BASE_PATH with subdirectory', () => {
       vi.stubEnv('BASE_PATH', '/occasional-wotd');
-      
+
       const rawPath = getWordUrl('serendipity');
       const processedUrl = getUrl(rawPath);
-      
+
       expect(rawPath).toBe('/words/serendipity');
       expect(processedUrl).toBe('/occasional-wotd/words/serendipity');
       expect(processedUrl).not.toContain('/occasional-wotd/occasional-wotd/');
@@ -53,20 +53,20 @@ describe('WordLink Component Integration', () => {
 
     it('should handle multi-word phrases correctly', () => {
       vi.stubEnv('BASE_PATH', '/occasional-wotd');
-      
+
       const rawPath = getWordUrl('ice cream');
       const processedUrl = getUrl(rawPath);
-      
+
       expect(rawPath).toBe('/words/ice cream');
       expect(processedUrl).toBe('/occasional-wotd/words/ice cream');
     });
 
     it('should handle special characters in words', () => {
       vi.stubEnv('BASE_PATH', '/occasional-wotd');
-      
+
       const rawPath = getWordUrl("don't");
       const processedUrl = getUrl(rawPath);
-      
+
       expect(rawPath).toBe("/words/don't");
       expect(processedUrl).toBe("/occasional-wotd/words/don't");
     });
@@ -75,14 +75,14 @@ describe('WordLink Component Integration', () => {
   describe('Real-world GitHub Pages scenarios', () => {
     it('should match expected GitHub Pages URLs', () => {
       vi.stubEnv('BASE_PATH', '/occasional-wotd');
-      
-      const testCases = [
-        { word: 'serendipity', expected: '/occasional-wotd/words/serendipity' },
-        { word: 'ice cream', expected: '/occasional-wotd/words/ice cream' },
-        { word: 'a', expected: '/occasional-wotd/words/a' },
-        { word: 'occasional', expected: '/occasional-wotd/words/occasional' }
-      ];
-      
+
+        const testCases = [
+          { word: 'serendipity', expected: '/occasional-wotd/words/serendipity' },
+          { word: 'ice cream', expected: '/occasional-wotd/words/ice cream' },
+          { word: 'a', expected: '/occasional-wotd/words/a' },
+          { word: 'occasional', expected: '/occasional-wotd/words/occasional' },
+        ];
+
       for (const { word, expected } of testCases) {
         const rawPath = getWordUrl(word);
         const processedUrl = getUrl(rawPath);
@@ -92,10 +92,10 @@ describe('WordLink Component Integration', () => {
 
     it('should work correctly for localhost development', () => {
       vi.stubEnv('BASE_PATH', '/');
-      
+
       const rawPath = getWordUrl('test');
       const processedUrl = getUrl(rawPath);
-      
+
       expect(rawPath).toBe('/words/test');
       expect(processedUrl).toBe('/words/test');
     });

--- a/tests/utils/page-metadata.spec.js
+++ b/tests/utils/page-metadata.spec.js
@@ -1,4 +1,10 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 
 import { getAllPageMetadata, getPageMetadata } from '~utils-client/page-metadata';
 
@@ -21,6 +27,13 @@ describe('page-metadata', () => {
         description: 'Browse the complete alphabetical list of all featured words, organized by year.',
         category: 'pages',
       });
+    });
+
+    it('handles BASE_PATH in pathname', () => {
+      vi.stubEnv('BASE_PATH', '/vocab');
+      const metadata = getPageMetadata('/vocab/words');
+      expect(metadata.title).toBe('All Words');
+      vi.unstubAllEnvs();
     });
 
     it('returns dynamic metadata for stats pages with counts', () => {


### PR DESCRIPTION
## Summary
- handle `BASE_PATH` when resolving page metadata
- test page metadata with `BASE_PATH`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894d1a9cff0832ab887df6397872e1d