### PR TITLE
refactor: replace mutable loops with immutable patterns

### DIFF
--- a/src/utils/static-paths-utils.ts
+++ b/src/utils/static-paths-utils.ts
@@ -103,18 +103,17 @@ const createStatsConfig = (words: WordData[]): StatsConfig[] => {
     {
       slug: STATS_SLUGS.CURRENT_STREAK,
       data: (() => {
-        const currentStreakWords: WordMilestoneItem[] = [];
-        if (streakStats.currentStreak > 0) {
-          const sorted = [...words].sort((a, b) => b.date.localeCompare(a.date));
-          for (let i = 0; i < streakStats.currentStreak && i < sorted.length; i++) {
-            currentStreakWords.push({
-              ...sorted[i],
-              label: `${ordinal(i + 1)} Day`,
-            });
-          }
-          currentStreakWords.reverse();
+        if (streakStats.currentStreak <= 0) {
+          return [];
         }
-        return currentStreakWords;
+        return [...words]
+          .sort((a, b) => b.date.localeCompare(a.date))
+          .slice(0, streakStats.currentStreak)
+          .map((w, i) => ({
+            ...w,
+            label: `${ordinal(i + 1)} Day`,
+          }))
+          .reverse();
       })(),
       def: DYNAMIC_STATS_DEFINITIONS[STATS_SLUGS.CURRENT_STREAK],
       template: TEMPLATE.MILESTONE,

--- a/src/utils/text-utils.ts
+++ b/src/utils/text-utils.ts
@@ -34,15 +34,12 @@ export function hasTripleLetters(word: string): boolean {
  */
 export function hasAlphabeticalSequence(word: string): boolean {
   const letters = word.toLowerCase().split('');
-  for (let i = 0; i < letters.length - 2; i++) {
+  return letters.slice(0, -2).some((_, i) => {
     const a = letters[i].charCodeAt(0);
     const b = letters[i + 1].charCodeAt(0);
     const c = letters[i + 2].charCodeAt(0);
-    if (b === a + 1 && c === b + 1) {
-      return true;
-    }
-  }
-  return false;
+    return b === a + 1 && c === b + 1;
+  });
 }
 
 /**

--- a/src/utils/word-stats-utils.ts
+++ b/src/utils/word-stats-utils.ts
@@ -246,29 +246,20 @@ export const getLongestStreakWords = (words: WordData[]): WordData[] => {
   }
 
   const sortedWords = [...words].sort((a, b) => b.date.localeCompare(a.date));
+  const [longest] = sortedWords.slice(1).reduce<[
+    WordData[],
+    WordData[],
+    WordData
+  ]>(([longest, current, prev], word) => {
+    const updatedCurrent = areConsecutiveDays(word.date, prev.date)
+      ? [...current, word]
+      : [word];
+    const updatedLongest =
+      updatedCurrent.length > longest.length ? updatedCurrent : longest;
+    return [updatedLongest, updatedCurrent, word];
+  }, [[sortedWords[0]], [sortedWords[0]], sortedWords[0]]);
 
-  let longestStreak: WordData[] = [];
-  let currentStreak: WordData[] = [sortedWords[0]];
-
-  for (let i = 1; i < sortedWords.length; i++) {
-    const currentWord = sortedWords[i];
-    const previousWord = sortedWords[i - 1];
-
-    if (areConsecutiveDays(currentWord.date, previousWord.date)) {
-      currentStreak.push(currentWord);
-    } else {
-      if (currentStreak.length > longestStreak.length) {
-        longestStreak = [...currentStreak];
-      }
-      currentStreak = [currentWord];
-    }
-  }
-
-  if (currentStreak.length > longestStreak.length) {
-    longestStreak = [...currentStreak];
-  }
-
-  return longestStreak.reverse();
+  return longest.slice().reverse();
 };
 
 /**
@@ -390,24 +381,17 @@ export function getChronologicalMilestones(words: WordData[]): Array<{milestone:
   if (words.length === 0) {
     return [];
   }
-
-  const milestones: Array<{milestone: number, word: WordData}> = [];
-
-  // Always add 1st word if it exists
-  if (words.length >= 1) {
-    milestones.push({ milestone: 1, word: words[0] });
-  }
-
-  // Add 25th, 50th, 75th, 100th, then every 100th after
-  [25, 50, 75].forEach(m => {
-    if (words.length >= m) {
-      milestones.push({ milestone: m, word: words[m - 1] });
-    }
-  });
-
-  for (let i = 100; i <= words.length; i += 100) {
-    milestones.push({ milestone: i, word: words[i - 1] });
-  }
-
-  return milestones;
+  return [
+    { milestone: 1, word: words[0] },
+    ...[25, 50, 75]
+      .filter(m => words.length >= m)
+      .map(m => ({ milestone: m, word: words[m - 1] })),
+    ...Array.from(
+      { length: Math.floor(words.length / 100) },
+      (_, idx) => {
+        const milestone = (idx + 1) * 100;
+        return { milestone, word: words[milestone - 1] };
+      },
+    ),
+  ];
 }


### PR DESCRIPTION
## Summary
- refactor text-utils, static-paths-utils, word-stats-utils, and regenerate-all-words to use immutable loops via array methods and for...of
- remove mutable counters in word regeneration tool in favor of derived outcomes
- adopt const-friendly patterns for generating streak and milestone data

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894d54ba654832a96d2a04c7dcecff1