### PR TITLE
feat: centralize environment configuration

### DIFF
--- a/config/environment.ts
+++ b/config/environment.ts
@@ -1,0 +1,86 @@
+import 'dotenv/config';
+
+interface Environment {
+  SITE_URL: string;
+  SITE_TITLE: string;
+  SITE_DESCRIPTION: string;
+  SITE_ID: string;
+  BASE_PATH: string;
+  SOURCE_DIR: string;
+  SITE_LOCALE: string;
+  SITE_AUTHOR: string;
+  SITE_AUTHOR_URL: string;
+  SITE_ATTRIBUTION_MESSAGE: string;
+  SITE_KEYWORDS: string[];
+  SENTRY_ENABLED: boolean;
+  NODE_ENV: string;
+  PACKAGE_VERSION: string;
+}
+
+const defaults = {
+  SITE_URL: 'https://localhost:4321',
+  SITE_TITLE: 'Occasional Word of the Day',
+  SITE_DESCRIPTION: 'A word-of-the-day site featuring interesting vocabulary',
+  SITE_ID: 'occasional-wotd',
+  SOURCE_DIR: 'demo',
+  BASE_PATH: '/',
+  SITE_LOCALE: 'en-US',
+} as const;
+
+const rawEnv: Record<string, string | undefined> = {
+  SITE_URL: process.env.SITE_URL,
+  SITE_TITLE: process.env.SITE_TITLE,
+  SITE_DESCRIPTION: process.env.SITE_DESCRIPTION,
+  SITE_ID: process.env.SITE_ID,
+  BASE_PATH: process.env.BASE_PATH,
+  SOURCE_DIR: process.env.SOURCE_DIR,
+  SITE_LOCALE: process.env.SITE_LOCALE,
+  SITE_AUTHOR: process.env.SITE_AUTHOR,
+  SITE_AUTHOR_URL: process.env.SITE_AUTHOR_URL,
+  SITE_ATTRIBUTION_MESSAGE: process.env.SITE_ATTRIBUTION_MESSAGE,
+  SITE_KEYWORDS: process.env.SITE_KEYWORDS,
+  SENTRY_ENABLED: process.env.SENTRY_ENABLED,
+  NODE_ENV: process.env.NODE_ENV,
+  PACKAGE_VERSION: process.env.npm_package_version,
+};
+
+Object.entries(defaults).forEach(([key, value]) => {
+  if (!rawEnv[key]) {
+    rawEnv[key] = value;
+  }
+});
+
+const required = ['SITE_URL', 'SITE_TITLE', 'SITE_DESCRIPTION', 'SITE_ID'] as const;
+const missing = required.filter((key) => !rawEnv[key]);
+if (missing.length > 0) {
+  throw new Error(`Missing required environment variables: ${missing.join(', ')}`);
+}
+
+function toBool(value: string | undefined, defaultValue = false): boolean {
+  if (value === undefined) {
+return defaultValue;
+}
+  return value === 'true';
+}
+
+export const env: Environment = {
+  SITE_URL: rawEnv.SITE_URL!,
+  SITE_TITLE: rawEnv.SITE_TITLE!,
+  SITE_DESCRIPTION: rawEnv.SITE_DESCRIPTION!,
+  SITE_ID: rawEnv.SITE_ID!,
+  BASE_PATH: rawEnv.BASE_PATH || '/',
+  SOURCE_DIR: rawEnv.SOURCE_DIR || 'demo',
+  SITE_LOCALE: rawEnv.SITE_LOCALE || 'en-US',
+  SITE_AUTHOR: rawEnv.SITE_AUTHOR || '',
+  SITE_AUTHOR_URL: rawEnv.SITE_AUTHOR_URL || '',
+  SITE_ATTRIBUTION_MESSAGE: rawEnv.SITE_ATTRIBUTION_MESSAGE || '',
+  SITE_KEYWORDS: rawEnv.SITE_KEYWORDS ? rawEnv.SITE_KEYWORDS.split(',').filter(Boolean) : [],
+  SENTRY_ENABLED: toBool(rawEnv.SENTRY_ENABLED),
+  NODE_ENV: rawEnv.NODE_ENV || 'production',
+  PACKAGE_VERSION: rawEnv.PACKAGE_VERSION || '0.0.0',
+};
+
+export function getEnv<K extends keyof Environment>(key: K): Environment[K] {
+  return env[key];
+}
+

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -70,6 +70,8 @@ adapters/                    # Dictionary API adapters
 ```
 
 ## Environment Configuration
+Environment variables are centralized in `config/environment.ts`. This module loads variables at startup,
+applies development defaults, validates required values, and exposes typed getters for use throughout the codebase.
 
 ### Required Variables
 ```bash

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,11 +1,12 @@
 ---
 import wordnikLogo from '~assets/wordnik-gearheart.png';
 import SiteLink from '~components/SiteLink.astro';
+import { env } from '~config/environment';
 
 const currentYear = new Date().getFullYear();
-const attributionUrl = import.meta.env.SITE_AUTHOR_URL;
-const authorName = import.meta.env.SITE_AUTHOR;
-const attributionMessage = import.meta.env.SITE_ATTRIBUTION_MESSAGE;
+const attributionUrl = env.SITE_AUTHOR_URL;
+const authorName = env.SITE_AUTHOR;
+const attributionMessage = env.SITE_ATTRIBUTION_MESSAGE;
 const showAttribution = attributionUrl && authorName && attributionMessage;
 ---
 

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,10 +1,11 @@
 ---
 import SiteLink from '~components/SiteLink.astro';
+import { env } from '~config/environment';
 ---
 
 <header class="header">
   <SiteLink href="/" class="header__link" ariaLabel="Return to home page">
-    <h2 class="header__title">{import.meta.env.SITE_TITLE}</h2>
+    <h2 class="header__title">{env.SITE_TITLE}</h2>
   </SiteLink>
 </header>
 

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,5 +1,6 @@
 import type { APIRoute } from 'astro';
 
+import { env } from '~config/environment';
 import { generateRobotsTxt } from '~utils-client/static-file-utils';
 
 /**
@@ -7,11 +8,7 @@ import { generateRobotsTxt } from '~utils-client/static-file-utils';
  * @returns Plain text robots.txt content
  */
 export const GET: APIRoute = () => {
-  const siteUrl = import.meta.env.SITE_URL;
-  if (!siteUrl) {
-    throw new Error('SITE_URL environment variable is required for robots.txt generation');
-  }
-  const robotsTxt = generateRobotsTxt(siteUrl);
+  const robotsTxt = generateRobotsTxt(env.SITE_URL);
 
   return new Response(robotsTxt, {
     headers: {

--- a/src/utils/image-utils.ts
+++ b/src/utils/image-utils.ts
@@ -1,3 +1,4 @@
+import { env } from '~config/environment';
 import type { WordData } from '~types/word';
 
 /**
@@ -6,18 +7,18 @@ import type { WordData } from '~types/word';
  * @returns URL to the social image
  */
 export function getSocialImageUrl({ pathname, wordData }: { pathname: string; wordData?: WordData | null }): string {
-  const basePath = import.meta.env.BASE_PATH || '/';
+  const basePath = env.BASE_PATH || '/';
   const cleanPath = pathname.startsWith('/') ? pathname.slice(1) : pathname;
 
   if (wordData && wordData.word) {
     // Word-specific social image
-    return `${basePath}images/social/${import.meta.env.SOURCE_DIR || 'demo'}/2025/${wordData.date}-${wordData.word}.png`;
+    return `${basePath}images/social/${env.SOURCE_DIR || 'demo'}/2025/${wordData.date}-${wordData.word}.png`;
   }
 
   if (cleanPath.startsWith('words/')) {
     // Word path without specific data
     const wordPath = cleanPath.replace('words/', '');
-    return `${basePath}images/social/${import.meta.env.SOURCE_DIR || 'demo'}/2025/${wordPath}.png`;
+    return `${basePath}images/social/${env.SOURCE_DIR || 'demo'}/2025/${wordPath}.png`;
   }
 
   // Generic page social image

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -12,11 +12,12 @@
  * - Optional Sentry integration (decoupled)
  */
 
+import { env } from '~config/environment';
 import { logError } from '~utils-client/sentry-client';
 
 // Fast-fail environment configuration
-const isDev = import.meta.env?.DEV ?? false;
-const sentryEnabled = import.meta.env?.SENTRY_ENABLED === 'true';
+const isDev = env.NODE_ENV !== 'production';
+const sentryEnabled = env.SENTRY_ENABLED;
 
 
 /**
@@ -61,7 +62,7 @@ return;
 export const config = {
   isDev,
   sentryEnabled,
-  version: import.meta.env?.npm_package_version ?? '0.0.0',
+  version: env.PACKAGE_VERSION,
 } as const;
 
 /**

--- a/src/utils/page-metadata.ts
+++ b/src/utils/page-metadata.ts
@@ -1,5 +1,6 @@
 import { format } from 'date-fns';
 
+import { env } from '~config/environment';
 import type { WordData } from '~types/word';
 import { MONTH_NAMES, monthSlugToNumber } from '~utils/date-utils';
 import { logger } from '~utils-client/logger';
@@ -309,7 +310,7 @@ export function getPageMetadata(pathname?: string, words: WordData[] = allWords)
 throw new Error('getPageMetadata: pathname is required. Pass Astro.url.pathname from your page.');
 }
     let path = pathname.replace(/^\//, '').replace(/\/$/, '');
-    const basePath = import.meta.env.BASE_PATH?.replace(/^\/|\/$/g, '') || '';
+    const basePath = env.BASE_PATH.replace(/^\/|\/$/g, '') || '';
     if (basePath && (path === basePath || path.startsWith(`${basePath}/`))) {
       path = path.slice(basePath.length).replace(/^\//, '');
     }

--- a/src/utils/sentry-client.ts
+++ b/src/utils/sentry-client.ts
@@ -1,5 +1,6 @@
 import { captureException, captureMessage, withScope } from '@sentry/astro';
 
+import { env } from '~config/environment';
 import type { LogContext } from '~types/common';
 
 /**
@@ -10,7 +11,7 @@ import type { LogContext } from '~types/common';
  * @returns {void} Nothing
  */
 export function logError(error: Error | string, context: LogContext = {}, level: 'error' | 'warning' | 'info' = 'error'): void {
-  if (import.meta.env.SENTRY_ENABLED !== 'true') {
+  if (!env.SENTRY_ENABLED) {
     return;
   }
   if (Object.keys(context).length > 0) {

--- a/src/utils/seo-utils.ts
+++ b/src/utils/seo-utils.ts
@@ -3,19 +3,20 @@
  * Centralized SEO config following Astro best practices
  */
 
+import { env } from '~config/environment';
 import type { SeoConfig, SeoMetadata, SeoMetadataOptions, SeoMetaDescriptionOptions } from '~types/seo';
 import { getFullUrl } from '~utils-client/url-utils';
 
 // SEO configuration using environment variables - no fallbacks for security
 export const seoConfig: SeoConfig = {
-  defaultTitle: import.meta.env.SITE_TITLE,
-  defaultDescription: import.meta.env.SITE_DESCRIPTION,
-  siteName: import.meta.env.SITE_ID,
-  locale: import.meta.env.SITE_LOCALE || 'en-US',
-  author: import.meta.env.SITE_AUTHOR,
-  authorUrl: import.meta.env.SITE_AUTHOR_URL,
-  attributionMessage: import.meta.env.SITE_ATTRIBUTION_MESSAGE,
-  keywords: (import.meta.env.SITE_KEYWORDS || '').split(',').filter(Boolean),
+  defaultTitle: env.SITE_TITLE,
+  defaultDescription: env.SITE_DESCRIPTION,
+  siteName: env.SITE_ID,
+  locale: env.SITE_LOCALE,
+  author: env.SITE_AUTHOR,
+  authorUrl: env.SITE_AUTHOR_URL,
+  attributionMessage: env.SITE_ATTRIBUTION_MESSAGE,
+  keywords: env.SITE_KEYWORDS,
 };
 
 

--- a/src/utils/url-utils.ts
+++ b/src/utils/url-utils.ts
@@ -1,3 +1,4 @@
+import { env } from '~config/environment';
 import { logger } from '~utils-client/logger';
 
 /**
@@ -7,7 +8,7 @@ import { logger } from '~utils-client/logger';
  * @returns Normalized URL path
  */
 export const getUrl = (path = '/'): string => {
-  const baseUrl = import.meta.env.BASE_PATH || '/';
+  const baseUrl = env.BASE_PATH || '/';
 
   if (!path || path === '') {
     return baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
@@ -39,14 +40,8 @@ export const getUrl = (path = '/'): string => {
  * @returns Absolute URL
  */
 export const getFullUrl = (path = '/'): string => {
-  const siteUrl = import.meta.env.SITE_URL?.replace(/\/$/, '') || '';
+  const siteUrl = env.SITE_URL.replace(/\/$/, '');
   const relativePath = getUrl(path);
-
-  if (!siteUrl) {
-    logger.error('SITE_URL environment variable is required for getFullUrl');
-    throw new Error('SITE_URL environment variable is required');
-  }
-
   return `${siteUrl}${relativePath}`;
 };
 

--- a/tests/config/environment.spec.js
+++ b/tests/config/environment.spec.js
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest';
+
+describe('config/environment', () => {
+  it('provides defaults when env vars missing', async () => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    const { env } = await import('~config/environment');
+    expect(env.SITE_URL).toBe('https://localhost:4321');
+    expect(env.SITE_TITLE).toBe('Occasional Word of the Day');
+  });
+
+  it('uses provided environment variables', async () => {
+    vi.resetModules();
+    vi.stubEnv('SITE_URL', 'https://example.com');
+    vi.stubEnv('SITE_TITLE', 'My Site');
+    vi.stubEnv('SITE_DESCRIPTION', 'Desc');
+    vi.stubEnv('SITE_ID', 'my-site');
+    const { env } = await import('~config/environment');
+    expect(env.SITE_URL).toBe('https://example.com');
+    expect(env.SITE_TITLE).toBe('My Site');
+    expect(env.SITE_DESCRIPTION).toBe('Desc');
+    expect(env.SITE_ID).toBe('my-site');
+  });
+});

--- a/tests/src/components/WordLink.spec.js
+++ b/tests/src/components/WordLink.spec.js
@@ -6,82 +6,81 @@ import {
   vi,
 } from 'vitest';
 
-import { getUrl, getWordUrl } from '~utils-client/url-utils';
-
 describe('WordLink Component Integration', () => {
   beforeEach(() => {
-    vi.stubEnv('BASE_PATH', '/');
+    vi.resetModules();
   });
 
   describe('getWordUrl', () => {
-    it('should return relative path without BASE_PATH processing', () => {
+    it('should return relative path without BASE_PATH processing', async () => {
+      vi.stubEnv('BASE_PATH', '/');
+      const { getWordUrl } = await import('~utils-client/url-utils');
       expect(getWordUrl('serendipity')).toBe('/words/serendipity');
       expect(getWordUrl('ice cream')).toBe('/words/ice cream');
     });
 
-    it('should return empty string for empty word', () => {
+    it('should return empty string for empty word', async () => {
+      vi.stubEnv('BASE_PATH', '/');
+      const { getWordUrl } = await import('~utils-client/url-utils');
       expect(getWordUrl('')).toBe('');
     });
 
-    it('should work regardless of BASE_PATH', () => {
+    it('should work regardless of BASE_PATH', async () => {
       vi.stubEnv('BASE_PATH', '/occasional-wotd');
+      const { getWordUrl } = await import('~utils-client/url-utils');
       expect(getWordUrl('test')).toBe('/words/test');
     });
   });
 
   describe('WordLink + SiteLink integration flow', () => {
-    it('should prevent double BASE_PATH with no subdirectory', () => {
+    it('should prevent double BASE_PATH with no subdirectory', async () => {
       vi.stubEnv('BASE_PATH', '/');
-
+      const { getUrl, getWordUrl } = await import('~utils-client/url-utils');
       const rawPath = getWordUrl('serendipity');
       const processedUrl = getUrl(rawPath);
-
       expect(rawPath).toBe('/words/serendipity');
       expect(processedUrl).toBe('/words/serendipity');
     });
 
-    it('should prevent double BASE_PATH with subdirectory', () => {
+    it('should prevent double BASE_PATH with subdirectory', async () => {
       vi.stubEnv('BASE_PATH', '/occasional-wotd');
-
+      const { getUrl, getWordUrl } = await import('~utils-client/url-utils');
       const rawPath = getWordUrl('serendipity');
       const processedUrl = getUrl(rawPath);
-
       expect(rawPath).toBe('/words/serendipity');
       expect(processedUrl).toBe('/occasional-wotd/words/serendipity');
       expect(processedUrl).not.toContain('/occasional-wotd/occasional-wotd/');
     });
 
-    it('should handle multi-word phrases correctly', () => {
+    it('should handle multi-word phrases correctly', async () => {
       vi.stubEnv('BASE_PATH', '/occasional-wotd');
-
+      const { getUrl, getWordUrl } = await import('~utils-client/url-utils');
       const rawPath = getWordUrl('ice cream');
       const processedUrl = getUrl(rawPath);
-
       expect(rawPath).toBe('/words/ice cream');
       expect(processedUrl).toBe('/occasional-wotd/words/ice cream');
     });
 
-    it('should handle special characters in words', () => {
+    it('should handle special characters in words', async () => {
       vi.stubEnv('BASE_PATH', '/occasional-wotd');
-
+      const { getUrl, getWordUrl } = await import('~utils-client/url-utils');
       const rawPath = getWordUrl("don't");
       const processedUrl = getUrl(rawPath);
-
       expect(rawPath).toBe("/words/don't");
       expect(processedUrl).toBe("/occasional-wotd/words/don't");
     });
   });
 
   describe('Real-world GitHub Pages scenarios', () => {
-    it('should match expected GitHub Pages URLs', () => {
+    it('should match expected GitHub Pages URLs', async () => {
       vi.stubEnv('BASE_PATH', '/occasional-wotd');
-
-        const testCases = [
-          { word: 'serendipity', expected: '/occasional-wotd/words/serendipity' },
-          { word: 'ice cream', expected: '/occasional-wotd/words/ice cream' },
-          { word: 'a', expected: '/occasional-wotd/words/a' },
-          { word: 'occasional', expected: '/occasional-wotd/words/occasional' },
-        ];
+      const { getUrl, getWordUrl } = await import('~utils-client/url-utils');
+      const testCases = [
+        { word: 'serendipity', expected: '/occasional-wotd/words/serendipity' },
+        { word: 'ice cream', expected: '/occasional-wotd/words/ice cream' },
+        { word: 'a', expected: '/occasional-wotd/words/a' },
+        { word: 'occasional', expected: '/occasional-wotd/words/occasional' },
+      ];
 
       for (const { word, expected } of testCases) {
         const rawPath = getWordUrl(word);
@@ -90,12 +89,11 @@ describe('WordLink Component Integration', () => {
       }
     });
 
-    it('should work correctly for localhost development', () => {
+    it('should work correctly for localhost development', async () => {
       vi.stubEnv('BASE_PATH', '/');
-
+      const { getUrl, getWordUrl } = await import('~utils-client/url-utils');
       const rawPath = getWordUrl('test');
       const processedUrl = getUrl(rawPath);
-
       expect(rawPath).toBe('/words/test');
       expect(processedUrl).toBe('/words/test');
     });

--- a/tests/utils/page-metadata.spec.js
+++ b/tests/utils/page-metadata.spec.js
@@ -29,9 +29,11 @@ describe('page-metadata', () => {
       });
     });
 
-    it('handles BASE_PATH in pathname', () => {
+    it('handles BASE_PATH in pathname', async () => {
       vi.stubEnv('BASE_PATH', '/vocab');
-      const metadata = getPageMetadata('/vocab/words');
+      vi.resetModules();
+      const { getPageMetadata: fresh } = await import('~utils-client/page-metadata');
+      const metadata = fresh('/vocab/words');
       expect(metadata.title).toBe('All Words');
       vi.unstubAllEnvs();
     });

--- a/tests/utils/url-utils.spec.js
+++ b/tests/utils/url-utils.spec.js
@@ -2,97 +2,109 @@ import {
  beforeEach, describe, expect, it, vi,
 } from 'vitest';
 
-import { getFullUrl, getUrl } from '~utils-client/url-utils';
-
 describe('utils', () => {
   describe('getUrl', () => {
     beforeEach(() => {
+      vi.resetModules();
+    });
+
+    it('handles paths with default base path', async () => {
       vi.stubEnv('BASE_PATH', '/');
-    });
-
-    it('handles paths with default base path', () => {
+      const { getUrl } = await import('~utils-client/url-utils');
       expect(getUrl('/20240319')).toBe('/20240319');
     });
 
-    it('handles paths with custom base path', () => {
+    it('handles paths with custom base path', async () => {
       vi.stubEnv('BASE_PATH', '/blog');
+      const { getUrl } = await import('~utils-client/url-utils');
       expect(getUrl('/20240319')).toBe('/blog/20240319');
     });
 
-    it('handles paths with custom base path with trailing slash', () => {
+    it('handles paths with custom base path with trailing slash', async () => {
       vi.stubEnv('BASE_PATH', '/blog/');
+      const { getUrl } = await import('~utils-client/url-utils');
       expect(getUrl('/20240319')).toBe('/blog/20240319');
     });
 
-    it('handles empty or undefined base path', () => {
+    it('handles empty or undefined base path', async () => {
       vi.stubEnv('BASE_PATH', '');
+      const { getUrl } = await import('~utils-client/url-utils');
       expect(getUrl('/20240319')).toBe('/20240319');
     });
 
-    it('handles empty paths', () => {
+    it('handles empty paths', async () => {
+      vi.stubEnv('BASE_PATH', '/');
+      const { getUrl } = await import('~utils-client/url-utils');
       expect(getUrl('')).toBe('/');
       expect(getUrl('/')).toBe('/');
     });
 
-    it('handles null or undefined paths', () => {
+    it('handles null or undefined paths', async () => {
+      vi.stubEnv('BASE_PATH', '/');
+      const { getUrl } = await import('~utils-client/url-utils');
       expect(getUrl(null)).toBe('/');
       expect(getUrl(undefined)).toBe('/');
     });
 
-    it('rejects paths with multiple consecutive slashes', () => {
+    it('rejects paths with multiple consecutive slashes', async () => {
+      vi.stubEnv('BASE_PATH', '/');
+      const { getUrl } = await import('~utils-client/url-utils');
       expect(() => getUrl('//20240319')).toThrow('Invalid path: contains multiple consecutive slashes');
       expect(() => getUrl('///20240319')).toThrow('Invalid path: contains multiple consecutive slashes');
     });
 
-    it('preserves trailing slashes for root path only', () => {
+    it('preserves trailing slashes for root path only', async () => {
+      vi.stubEnv('BASE_PATH', '/');
+      const { getUrl } = await import('~utils-client/url-utils');
       expect(getUrl('/')).toBe('/');
       expect(getUrl('/20240319/')).toBe('/20240319');
     });
 
-    it('ignores SITE_URL when building relative URLs', () => {
+    it('ignores SITE_URL when building relative URLs', async () => {
       vi.stubEnv('BASE_PATH', '/blog');
       vi.stubEnv('SITE_URL', 'https://example.com');
+      const { getUrl } = await import('~utils-client/url-utils');
       expect(getUrl('/words/hello')).toBe('/blog/words/hello');
     });
 
-    it('preserves case for base path and path', () => {
+    it('preserves case for base path and path', async () => {
       vi.stubEnv('BASE_PATH', '/Blog');
+      const { getUrl } = await import('~utils-client/url-utils');
       expect(getUrl('/ABC')).toBe('/Blog/ABC');
     });
   });
 
   describe('getFullUrl', () => {
     beforeEach(() => {
-      vi.stubEnv('BASE_PATH', '/');
-      vi.stubEnv('SITE_URL', 'https://example.com');
+      vi.resetModules();
     });
 
-    it('combines SITE_URL with getUrl() result', () => {
+    it('combines SITE_URL with getUrl() result', async () => {
+      vi.stubEnv('BASE_PATH', '/');
+      vi.stubEnv('SITE_URL', 'https://example.com');
+      const { getFullUrl } = await import('~utils-client/url-utils');
       expect(getFullUrl('/words/hello')).toBe('https://example.com/words/hello');
     });
 
-    it('handles subdirectory deployments correctly', () => {
+    it('handles subdirectory deployments correctly', async () => {
       vi.stubEnv('BASE_PATH', '/vocab');
+      vi.stubEnv('SITE_URL', 'https://example.com');
+      const { getFullUrl } = await import('~utils-client/url-utils');
       expect(getFullUrl('/words/hello')).toBe('https://example.com/vocab/words/hello');
     });
 
-    it('handles root path correctly', () => {
+    it('handles root path correctly', async () => {
+      vi.stubEnv('BASE_PATH', '/');
+      vi.stubEnv('SITE_URL', 'https://example.com');
+      const { getFullUrl } = await import('~utils-client/url-utils');
       expect(getFullUrl('/')).toBe('https://example.com/');
     });
 
-    it('throws when SITE_URL is missing', () => {
-      vi.stubEnv('SITE_URL', '');
-      expect(() => getFullUrl('/test')).toThrow('SITE_URL environment variable is required');
-    });
-
-    it('removes trailing slash from SITE_URL', () => {
+    it('removes trailing slash from SITE_URL', async () => {
+      vi.stubEnv('BASE_PATH', '/');
       vi.stubEnv('SITE_URL', 'https://example.com/');
+      const { getFullUrl } = await import('~utils-client/url-utils');
       expect(getFullUrl('/test')).toBe('https://example.com/test');
-    });
-
-    it('uses default site URL when none provided', () => {
-      vi.stubEnv('SITE_URL', '');
-      expect(() => getFullUrl('/')).toThrow('SITE_URL environment variable is required');
     });
   });
 });


### PR DESCRIPTION
## Summary
- add typed environment module with validation and defaults
- refactor utilities and Astro config to use centralized env getters
- document environment module usage

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894d5580150832a99d67534262949a3