### PR TITLE
refactor: consolidate type definitions

### DIFF
--- a/adapters/index.ts
+++ b/adapters/index.ts
@@ -1,5 +1,5 @@
 import { wordnikAdapter } from '~adapters/wordnik';
-import type { DictionaryAdapter } from '~types/adapters';
+import type { DictionaryAdapter } from '~types';
 import { logger } from '~astro-utils/logger';
 
 /**

--- a/adapters/wordnik.ts
+++ b/adapters/wordnik.ts
@@ -1,9 +1,15 @@
 import { decodeHTML } from 'entities';
 
-import type { DictionaryAdapter, DictionaryResponse } from '~types/adapters';
-import type { DictionaryDefinition, FetchOptions } from '~types/common';
-import type { WordData, WordProcessedData } from '~types/word';
-import type { WordnikConfig, WordnikDefinition } from '~types/wordnik';
+import type {
+  DictionaryAdapter,
+  DictionaryResponse,
+  DictionaryDefinition,
+  FetchOptions,
+  WordData,
+  WordProcessedData,
+  WordnikConfig,
+  WordnikDefinition,
+} from '~types';
 
 /**
  * Configuration constants for Wordnik API integration

--- a/config/paths.ts
+++ b/config/paths.ts
@@ -6,7 +6,7 @@
 
 import path from 'path';
 
-import type { PathConfig } from '~types/common';
+import type { PathConfig } from '~types';
 
 const ROOT = process.cwd();
 const getWordsPath = (): string => {

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -9,7 +9,8 @@
       "~utils/*": ["utils/*"],
       "~data/*": ["data/*"],
       "~config/*": ["config/*"],
-      "~types/*": ["src/types/*"]
+      "~types": ["types"],
+      "~types/*": ["types/*"]
     },
     "jsx": "preserve",
     "jsxImportSource": "astro"

--- a/src/components/StatsMilestonePage.astro
+++ b/src/components/StatsMilestonePage.astro
@@ -3,7 +3,7 @@ import DescriptionText from '~components/DescriptionText.astro';
 import Heading from '~components/Heading.astro';
 import WordLink from '~components/WordLink.astro';
 import Layout from '~layouts/Layout.astro';
-import type { WordMilestoneItem } from '~types/word';
+import type { WordMilestoneItem } from '~types';
 import { getPageMetadata } from '~astro-utils/page-metadata.ts';
 import { STRUCTURED_DATA_TYPE } from '~astro-utils/schema-utils.ts';
 import { formatWordCount } from '~utils/text-utils';

--- a/src/components/StatsWordListPage.astro
+++ b/src/components/StatsWordListPage.astro
@@ -3,7 +3,7 @@ import DescriptionText from '~components/DescriptionText.astro';
 import Heading from '~components/Heading.astro';
 import WordSection from '~components/WordSection.astro';
 import Layout from '~layouts/Layout.astro';
-import type { WordData } from '~types/word';
+import type { WordData } from '~types';
 import { getPageMetadata } from '~astro-utils/page-metadata.ts';
 import { STRUCTURED_DATA_TYPE } from '~astro-utils/schema-utils.ts';
 import { formatWordCount } from '~utils/text-utils';

--- a/src/components/StructuredData.astro
+++ b/src/components/StructuredData.astro
@@ -1,6 +1,6 @@
 ---
 
-import type { CollectionPageSchema, DefinedTermSchema, WebSiteSchema, WordSchemaData } from '~types/schema';
+import type { CollectionPageSchema, DefinedTermSchema, WebSiteSchema, WordSchemaData } from '~types';
 import { STRUCTURED_DATA_TYPE, type StructuredDataType } from '~astro-utils/schema-utils.ts';
 import { seoConfig } from '~astro-utils/seo-utils.ts';
 import { getFullUrl } from '~astro-utils/url-utils';

--- a/src/components/Word.astro
+++ b/src/components/Word.astro
@@ -1,7 +1,7 @@
 ---
 import Heading from '~components/Heading.astro';
 import WordDescription from '~components/WordDescription.astro';
-import type { WordData } from '~types/word';
+import type { WordData } from '~types';
 import { formatDate } from '~utils/date-utils';
 import { getWordDetails } from '~astro-utils/word-data-utils';
 

--- a/src/components/WordDescription.astro
+++ b/src/components/WordDescription.astro
@@ -1,5 +1,5 @@
 ---
-import type { SourceMeta } from '~types/common';
+import type { SourceMeta } from '~types';
 
 interface Props {
   partOfSpeech: string;

--- a/src/components/WordPage.astro
+++ b/src/components/WordPage.astro
@@ -2,7 +2,7 @@
 import WordComponent from '~components/Word.astro';
 import WordNav from '~components/WordNav.astro';
 import Layout from '~layouts/Layout.astro';
-import type { WordData } from '~types/word';
+import type { WordData } from '~types';
 import { STRUCTURED_DATA_TYPE } from '~astro-utils/schema-utils.ts';
 import { getMetaDescription } from '~astro-utils/seo-utils.ts';
 import { extractWordDefinition } from '~astro-utils/word-data-utils';

--- a/src/components/WordSection.astro
+++ b/src/components/WordSection.astro
@@ -1,7 +1,7 @@
 ---
 import SectionHeading from '~components/SectionHeading.astro';
 import WordList from '~components/WordList.astro';
-import type { WordData } from '~types/word';
+import type { WordData } from '~types';
 
 interface Props {
   title?: string;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -5,7 +5,7 @@ import '~styles/theme.css';
 import Footer from '~components/Footer.astro';
 import Header from '~components/Header.astro';
 import StructuredData from '~components/StructuredData.astro';
-import type { WordData } from '~types/word';
+import type { WordData } from '~types';
 import { getBuildData } from '~astro-utils/build-utils.ts';
 import { getSocialImageUrl } from '~astro-utils/image-utils';
 import { getMetaDescription, seoConfig } from '~astro-utils/seo-utils.ts';

--- a/src/pages/stats/[stat].astro
+++ b/src/pages/stats/[stat].astro
@@ -5,7 +5,7 @@ import { generateStatsStaticPaths } from '~astro-utils/static-paths-utils';
 
 export const getStaticPaths = generateStatsStaticPaths;
 
-import type { WordData, WordMilestoneItem } from '~types/word';
+import type { WordData, WordMilestoneItem } from '~types';
 
 const { words, description, template } = Astro.props;
 

--- a/src/utils/build-utils.ts
+++ b/src/utils/build-utils.ts
@@ -1,4 +1,4 @@
-import type { WordData } from '~types/word';
+import type { WordData } from '~types';
 import { generateWordDataHash } from '~astro-utils/word-data-utils';
 
 export interface BuildData {

--- a/src/utils/image-utils.ts
+++ b/src/utils/image-utils.ts
@@ -1,4 +1,4 @@
-import type { WordData } from '~types/word';
+import type { WordData } from '~types';
 
 /**
  * Get social media image URL for a word or page

--- a/src/utils/schema-utils.ts
+++ b/src/utils/schema-utils.ts
@@ -3,7 +3,7 @@
  * Simple JSON-LD generation with proper typing
  */
 
-import type { CollectionPageSchema, DefinedTermSchema, WebSiteSchema, WordSchemaData } from '~types/schema';
+import type { CollectionPageSchema, DefinedTermSchema, WebSiteSchema, WordSchemaData } from '~types';
 import { seoConfig } from '~astro-utils/seo-utils';
 import { getFullUrl } from '~astro-utils/url-utils';
 

--- a/src/utils/sentry-client.ts
+++ b/src/utils/sentry-client.ts
@@ -1,6 +1,6 @@
 import { captureException, captureMessage, withScope } from '@sentry/astro';
 
-import type { LogContext } from '~types/common';
+import type { LogContext } from '~types';
 
 /**
  * Log an error to Sentry with optional context

--- a/src/utils/seo-utils.ts
+++ b/src/utils/seo-utils.ts
@@ -3,7 +3,7 @@
  * Centralized SEO config following Astro best practices
  */
 
-import type { SeoConfig, SeoMetadata, SeoMetadataOptions, SeoMetaDescriptionOptions } from '~types/seo';
+import type { SeoConfig, SeoMetadata, SeoMetadataOptions, SeoMetaDescriptionOptions } from '~types';
 import { getFullUrl } from '~astro-utils/url-utils';
 
 // SEO configuration using environment variables - no fallbacks for security

--- a/src/utils/static-file-utils.ts
+++ b/src/utils/static-file-utils.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import type { WordData } from '~types/word';
+import type { WordData } from '~types';
 import { formatDate } from '~utils/date-utils';
 import { getAllPageMetadata } from '~utils/page-metadata-utils';
 import { generateWordDataHash } from '~astro-utils/word-data-utils';

--- a/src/utils/static-paths-utils.ts
+++ b/src/utils/static-paths-utils.ts
@@ -22,7 +22,7 @@ const ordinal = (n: number): string => {
   return n + (suffixes[(remainder - 20) % 10] || suffixes[remainder] || suffixes[0]);
 };
 
-import type { WordData, WordMilestoneItem } from '~types/word';
+import type { WordData, WordMilestoneItem } from '~types';
 
 // Template constants
 const TEMPLATE = {

--- a/src/utils/word-data-utils.ts
+++ b/src/utils/word-data-utils.ts
@@ -7,7 +7,7 @@ import type {
   WordGroupByLengthResult,
   WordGroupByYearResult,
   WordProcessedData,
-} from '~types/word';
+} from '~types';
 import { getMonthSlugFromDate } from '~utils/date-utils';
 import { logger } from '~astro-utils/logger';
 

--- a/src/utils/word-stats-utils.ts
+++ b/src/utils/word-stats-utils.ts
@@ -5,7 +5,7 @@ import type {
   WordPatternStatsResult,
   WordStatsResult,
   WordStreakStatsResult,
-} from '~types/word';
+} from '~types';
 import { dateToYYYYMMDD, YYYYMMDDToDate } from '~utils/date-utils';
 import { logger } from '~astro-utils/logger';
 import {

--- a/tools/add-word.ts
+++ b/tools/add-word.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import { paths } from '~config/paths';
 import { COMMON_ENV_DOCS,showHelp } from '~tools/help-utils';
 import { createWordEntry, findExistingWord } from '~tools/utils';
-import type { WordData } from '~types/word';
+import type { WordData } from '~types';
 import { getTodayYYYYMMDD, isValidDate } from '~utils/date-utils';
 
 /**

--- a/tools/regenerate-all-words.ts
+++ b/tools/regenerate-all-words.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import { getAdapter } from '~adapters';
 import { COMMON_ENV_DOCS,showHelp } from '~tools/help-utils';
 import { getAllWords } from '~tools/utils';
-import type { WordData } from '~types/word';
+import type { WordData } from '~types';
 import { isValidDictionaryData } from '~utils/word-validation';
 
 interface RegenerateOptions {

--- a/tools/utils.ts
+++ b/tools/utils.ts
@@ -348,9 +348,7 @@ export async function generateGenericShareImage(title: string, slug: string): Pr
 }
 
 import { getAdapter } from '~adapters';
-import type { CreateWordEntryResult } from '~types/common';
-import type { WordData } from '~types/word';
-import type { WordnikResponse } from '~types/wordnik';
+import type { CreateWordEntryResult, WordData, WordnikResponse } from '~types';
 import { formatDate, isValidDate } from '~utils/date-utils';
 import { isValidDictionaryData } from '~utils/word-validation';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
       "~utils/*": ["./utils/*"],
       "~adapters": ["./adapters"],
       "~adapters/*": ["./adapters/*"],
+      "~types": ["./types"],
       "~types/*": ["./types/*"],
       "~data/*": ["./data/*"],
       "~config/*": ["./config/*"],

--- a/types/adapters.ts
+++ b/types/adapters.ts
@@ -2,8 +2,7 @@
  * Common adapter interfaces for dictionary services
  */
 
-import type { DictionaryDefinition,FetchOptions, SourceMeta } from '~types/common';
-import type { WordData, WordProcessedData } from '~types/word';
+import type { DictionaryDefinition, FetchOptions, SourceMeta, WordData, WordProcessedData } from '~types';
 
 export interface DictionaryResponse {
   word: string;

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,0 +1,7 @@
+export * from './adapters';
+export * from './common';
+export * from './schema';
+export * from './seo';
+export * from './stats';
+export * from './word';
+export * from './wordnik';

--- a/types/schema.ts
+++ b/types/schema.ts
@@ -3,7 +3,7 @@
  * Focused on educational vocabulary content
  */
 
-import type { SourceMeta } from '~types/common';
+import type { SourceMeta } from '~types';
 
 // Website schema - appears on every page
 export interface WebSiteSchema {

--- a/types/stats.ts
+++ b/types/stats.ts
@@ -1,29 +1,9 @@
 /**
- * Base stats definition structure
+ * Stats definition structure with optional dynamic descriptions
  */
 export interface StatsDefinition {
   title: string;
-  pageDescription: string;
-  metaDescription: (count: number) => string;
-  category: 'stats';
-}
-
-/**
- * Static stats definition with string-only meta description
- */
-export interface StaticStatsDefinition {
-  title: string;
-  pageDescription: string;
-  metaDescription: string;
-  category: 'stats';
-}
-
-/**
- * Dynamic stats definition with function-based descriptions
- */
-export interface DynamicStatsDefinition {
-  title: string;
-  pageDescription: (arg?: string | number) => string;
+  pageDescription: string | ((arg?: string | number) => string);
   metaDescription: (count: number, arg?: string) => string;
   category: 'stats';
 }
@@ -71,6 +51,4 @@ export type SuffixStatsSlug = `words-ending-${SuffixKey}`;
 export type SuffixDefinition = StatsDefinition;
 export type LetterPatternDefinition = StatsDefinition;
 export type PatternDefinition = StatsDefinition;
-
-export type AnyStatsDefinition = DynamicStatsDefinition | SuffixDefinition | LetterPatternDefinition | PatternDefinition;
 

--- a/types/word.ts
+++ b/types/word.ts
@@ -2,7 +2,7 @@
  * Word data types - Our internal data structures
  */
 
-import type { DictionaryDefinition, SourceMeta } from '~types/common';
+import type { DictionaryDefinition, SourceMeta } from '~types';
 
 // Our processed word data after transformation
 export interface WordProcessedData {

--- a/types/wordnik.ts
+++ b/types/wordnik.ts
@@ -2,7 +2,7 @@
  * Wordnik API types - External API structures
  */
 
-import type { RateLimit } from '~types/common';
+import type { RateLimit } from '~types';
 
 export interface WordnikDefinition {
   id?: string;

--- a/utils/page-metadata-utils.ts
+++ b/utils/page-metadata-utils.ts
@@ -1,6 +1,6 @@
 import { format } from 'date-fns';
 
-import type { WordData } from '~types/word';
+import type { WordData } from '~types';
 import { MONTH_NAMES, monthSlugToNumber } from '~utils/date-utils';
 import { formatWordCount } from '~utils/text-utils';
 import {

--- a/utils/stats-definitions.ts
+++ b/utils/stats-definitions.ts
@@ -1,11 +1,4 @@
-import type {
-  DynamicStatsDefinition,
-  LetterPatternDefinition,
-  PatternDefinition,
-  StatsSlug,
-  SuffixDefinition,
-  SuffixKey,
-} from '~types/stats';
+import type { StatsDefinition, StatsSlug, SuffixKey } from '~types';
 import { formatWordCount } from '~utils/text-utils';
 
 // Stats page slug constants - defined here since this is where they're used
@@ -38,7 +31,7 @@ export const STATS_SLUGS = {
 } as const satisfies Record<string, StatsSlug>;
 
 // Word ending definitions
-export const SUFFIX_DEFINITIONS: Record<SuffixKey, SuffixDefinition> = {
+export const SUFFIX_DEFINITIONS: Record<SuffixKey, StatsDefinition> = {
   ed: {
     title: '-ed words',
     pageDescription: `Words ending with the suffix '-ed', typically indicating past tense or past participle forms.`,
@@ -78,7 +71,7 @@ export const SUFFIX_DEFINITIONS: Record<SuffixKey, SuffixDefinition> = {
 } as const;
 
 // Letter pattern definitions
-export const LETTER_PATTERN_DEFINITIONS: Record<string, LetterPatternDefinition> = {
+export const LETTER_PATTERN_DEFINITIONS: Record<string, StatsDefinition> = {
   [STATS_SLUGS.ALPHABETICAL_ORDER]: {
     title: 'Alphabetical Order',
     pageDescription: 'Words with three or more consecutive letters in alphabetical order.',
@@ -112,7 +105,7 @@ export const LETTER_PATTERN_DEFINITIONS: Record<string, LetterPatternDefinition>
 } as const;
 
 // Other pattern definitions
-export const PATTERN_DEFINITIONS: Record<string, PatternDefinition> = {
+export const PATTERN_DEFINITIONS: Record<string, StatsDefinition> = {
   [STATS_SLUGS.ALL_CONSONANTS]: {
     title: 'All Consonants',
     pageDescription: `Words made up of only consonants (no vowels).`,
@@ -128,7 +121,7 @@ export const PATTERN_DEFINITIONS: Record<string, PatternDefinition> = {
 } as const;
 
 // Special stats definitions that need dynamic data
-export const DYNAMIC_STATS_DEFINITIONS: Record<string, DynamicStatsDefinition> = {
+export const DYNAMIC_STATS_DEFINITIONS: Record<string, StatsDefinition> = {
   [STATS_SLUGS.MOST_COMMON_LETTER]: {
     title: 'Most Common Letter',
     pageDescription: (letter: string) => `Words containing the letter "${letter}" (appears in multiple words).`,

--- a/utils/word-data-utils.ts
+++ b/utils/word-data-utils.ts
@@ -1,4 +1,4 @@
-import type { WordData } from '~types/word';
+import type { WordData } from '~types';
 
 /**
  * Get words from a specific year

--- a/utils/word-stats-utils.ts
+++ b/utils/word-stats-utils.ts
@@ -1,4 +1,4 @@
-import type { WordData } from '~types/word';
+import type { WordData } from '~types';
 import { areConsecutiveDays, dateToYYYYMMDD } from '~utils/date-utils';
 
 // Text analysis functions needed by stats

--- a/utils/word-validation.ts
+++ b/utils/word-validation.ts
@@ -1,4 +1,4 @@
-import type { DictionaryDefinition } from '~types/common';
+import type { DictionaryDefinition } from '~types';
 
 /**
  * Validates dictionary data to ensure it contains meaningful content.


### PR DESCRIPTION
## Summary
- merge stats interfaces into a single `StatsDefinition`
- add `types/index.ts` barrel and path alias for `~types`
- update imports across repo to use consolidated types

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68964ece7698832a928e197e174b2c34