### PR TITLE
Handle BASE_PATH when resolving page metadata

### DIFF
--- a/src/utils/page-metadata.ts
+++ b/src/utils/page-metadata.ts
@@ -1,5 +1,31 @@
 import { allWords } from '~astro-utils/word-data-utils';
-import { getAllPageMetadata as getAllPageMetadataBase, getPageMetadata as getPageMetadataBase } from '~utils/page-metadata-utils';
+import {
+  getAllPageMetadata as getAllPageMetadataBase,
+  getPageMetadata as getPageMetadataBase,
+} from '~utils/page-metadata-utils';
+
+/**
+ * Remove BASE_PATH prefix from an incoming pathname
+ * Handles case differences and trailing slashes
+ * @param pathname - Raw pathname that may include the base path
+ * @returns Pathname relative to the site root
+ */
+function stripBasePath(pathname: string): string {
+  const base = (import.meta.env.BASE_PATH || '').replace(/\/+$/, '');
+
+  if (!base) {
+    return pathname.replace(/^\/+|\/+$/g, '');
+  }
+
+  const baseLower = base.toLowerCase();
+  const pathLower = pathname.toLowerCase();
+
+  if (pathLower.startsWith(baseLower)) {
+    return pathname.slice(base.length).replace(/^\/+|\/+$/g, '');
+  }
+
+  return pathname.replace(/^\/+|\/+$/g, '');
+}
 
 /**
  * Client-side functions partially applied with allWords
@@ -9,7 +35,8 @@ import { getAllPageMetadata as getAllPageMetadataBase, getPageMetadata as getPag
 /**
  * Get metadata for a specific page path
  */
-export const getPageMetadata = (pathname: string) => getPageMetadataBase(pathname, allWords);
+export const getPageMetadata = (pathname: string) =>
+  getPageMetadataBase(stripBasePath(pathname), allWords);
 
 /**
  * Get metadata for all pages

--- a/tests/utils/page-metadata-utils.spec.js
+++ b/tests/utils/page-metadata-utils.spec.js
@@ -2,6 +2,7 @@ import {
   describe,
   expect,
   it,
+  vi,
 } from 'vitest';
 
 import { getAllPageMetadata, getPageMetadata } from '~utils/page-metadata-utils';
@@ -144,6 +145,37 @@ describe('page-metadata-utils', () => {
       expect(allPages.find(page => page.path === 'words/2024')).toBeDefined();
       expect(allPages.find(page => page.path === 'words/length')).toBeDefined();
       expect(allPages.find(page => page.path === 'words/length/4')).toBeDefined();
+    });
+  });
+
+  describe('getPageMetadata wrapper', () => {
+    it('handles BASE_PATH prefixes', async () => {
+      vi.stubEnv('BASE_PATH', '/vocab');
+      const { getPageMetadata: getPageMetadataWrapper } = await import(
+        '~astro-utils/page-metadata'
+      );
+      const metadata = getPageMetadataWrapper('/vocab/stats');
+      expect(metadata).toEqual({
+        title: 'Stats',
+        description: 'Explore patterns and statistics from our word collection.',
+        category: 'pages',
+        secondaryText: 'For Nerds',
+      });
+    });
+
+    it('handles BASE_PATH with different case and trailing slash', async () => {
+      vi.stubEnv('BASE_PATH', '/Vocab/');
+      vi.resetModules();
+      const { getPageMetadata: getPageMetadataWrapper } = await import(
+        '~astro-utils/page-metadata'
+      );
+      const metadata = getPageMetadataWrapper('/vocab/stats');
+      expect(metadata).toEqual({
+        title: 'Stats',
+        description: 'Explore patterns and statistics from our word collection.',
+        category: 'pages',
+        secondaryText: 'For Nerds',
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary
- Replace URL parsing with `stripBasePath` helper to remove `BASE_PATH` prefix
- Ensure page-metadata wrapper strips base path before lookup
- Extend tests for mixed-case and trailing slash `BASE_PATH`

## Testing
- `npm run lint`
- `npm run astro sync`
- `npm run typecheck`
- `npm test`
- `npm run build` (emitted "getPageMetadata: pathname is required" but completed)


------
https://chatgpt.com/codex/tasks/task_e_68964e9e6b60832a9ee173c9ae0a2c6a