### PR TITLE
chore: enforce import order

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,7 +2,7 @@ import js from '@eslint/js';
 import tsParser from '@typescript-eslint/parser';
 import astroParser from 'astro-eslint-parser';
 import astro from 'eslint-plugin-astro';
-import simpleImportSort from 'eslint-plugin-simple-import-sort';
+import importPlugin from 'eslint-plugin-import';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
@@ -12,7 +12,7 @@ export default [
   ...astro.configs.recommended,
   {
     plugins: {
-      'simple-import-sort': simpleImportSort,
+      'import': importPlugin,
     },
     languageOptions: {
       ecmaVersion: 'latest',
@@ -58,8 +58,13 @@ export default [
       'object-curly-spacing': ['error', 'always'],
       'array-bracket-spacing': ['error', 'never'],
       'no-trailing-spaces': 'error',
-      'simple-import-sort/imports': 'error',
-      'simple-import-sort/exports': 'error',
+      'import/order': ['error', {
+        groups: ['builtin', 'external', 'internal', 'type'],
+        'newlines-between': 'always',
+        alphabetize: { order: 'asc', caseInsensitive: true },
+        pathGroups: [{ pattern: '~**', group: 'internal' }],
+        pathGroupsExcludedImportTypes: ['builtin'],
+      }],
       'nonblock-statement-body-position': ['error', 'below'],
       'object-curly-newline': ['error', {
         'ImportDeclaration': {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -59,7 +59,7 @@ export default [
       'array-bracket-spacing': ['error', 'never'],
       'no-trailing-spaces': 'error',
       'import/order': ['error', {
-        groups: ['builtin', 'external', 'internal', 'type'],
+        groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'type'],
         'newlines-between': 'always',
         alphabetize: { order: 'asc', caseInsensitive: true },
         pathGroups: [{ pattern: '~**', group: 'internal' }],

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,8 +1,8 @@
 ---
+import { getPageMetadata } from '~astro-utils/page-metadata.ts';
 import Heading from '~components/Heading.astro';
 import WordDescription from '~components/WordDescription.astro';
 import Layout from '~layouts/Layout.astro';
-import { getPageMetadata } from '~astro-utils/page-metadata.ts';
 
 const notFoundWord = {
   word: '404',

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,9 +1,9 @@
 ---
-import WordDisplay from '~components/WordDisplay.astro';
-import Layout from '~layouts/Layout.astro';
 import { getPageMetadata } from '~astro-utils/page-metadata.ts';
 import { STRUCTURED_DATA_TYPE } from '~astro-utils/schema-utils.ts';
-import { getCurrentWord,getWordsFromCollection } from '~astro-utils/word-data-utils';
+import { getCurrentWord, getWordsFromCollection } from '~astro-utils/word-data-utils';
+import WordDisplay from '~components/WordDisplay.astro';
+import Layout from '~layouts/Layout.astro';
 
 const allWords = await getWordsFromCollection();
 const currentWord = getCurrentWord(allWords);

--- a/src/pages/stats.astro
+++ b/src/pages/stats.astro
@@ -1,13 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 
-import Heading from '~components/Heading.astro';
-import SiteLink from '~components/SiteLink.astro';
-import WordLink from '~components/WordLink.astro';
-import Layout from '~layouts/Layout.astro';
 import { getPageMetadata } from '~astro-utils/page-metadata.ts';
-import { countSyllables, getConsonantCount, getVowelCount } from '~utils/text-utils';
-import { getAvailableLengths } from '~utils/word-data-utils';
 import {
   findWordDate,
   getChronologicalMilestones,
@@ -20,6 +14,12 @@ import {
   getWordEndingStats,
   getWordStats,
 } from '~astro-utils/word-stats-utils';
+import Heading from '~components/Heading.astro';
+import SiteLink from '~components/SiteLink.astro';
+import WordLink from '~components/WordLink.astro';
+import Layout from '~layouts/Layout.astro';
+import { countSyllables, getConsonantCount, getVowelCount } from '~utils/text-utils';
+import { getAvailableLengths } from '~utils/word-data-utils';
 
 const wordsCollection = await getCollection('words');
 const words = wordsCollection

--- a/src/pages/stats/[stat].astro
+++ b/src/pages/stats/[stat].astro
@@ -1,9 +1,8 @@
 ---
+export { generateStatsStaticPaths as getStaticPaths } from '~astro-utils/static-paths-utils';
+
 import StatsMilestonePage from '~components/StatsMilestonePage.astro';
 import StatsWordListPage from '~components/StatsWordListPage.astro';
-import { generateStatsStaticPaths } from '~astro-utils/static-paths-utils';
-
-export const getStaticPaths = generateStatsStaticPaths;
 
 import type { WordData, WordMilestoneItem } from '~types/word';
 

--- a/src/pages/words/[word].astro
+++ b/src/pages/words/[word].astro
@@ -1,6 +1,6 @@
 ---
-import WordPage from '~components/WordPage.astro';
 import { getAdjacentWords, getWordsFromCollection } from '~astro-utils/word-data-utils';
+import WordPage from '~components/WordPage.astro';
 
 export async function getStaticPaths() {
   const allWords = await getWordsFromCollection();

--- a/src/pages/words/index.astro
+++ b/src/pages/words/index.astro
@@ -1,11 +1,11 @@
 ---
+import { getPageMetadata } from '~astro-utils/page-metadata.ts';
+import { STRUCTURED_DATA_TYPE } from '~astro-utils/schema-utils.ts';
+import { getWordsFromCollection, groupWordsByYear } from '~astro-utils/word-data-utils';
 import Heading from '~components/Heading.astro';
 import WordSection from '~components/WordSection.astro';
 import Layout from '~layouts/Layout.astro';
-import { getPageMetadata } from '~astro-utils/page-metadata.ts';
-import { STRUCTURED_DATA_TYPE } from '~astro-utils/schema-utils.ts';
 import { formatWordCount } from '~utils/text-utils';
-import { getWordsFromCollection, groupWordsByYear } from '~astro-utils/word-data-utils';
 
 const allWords = await getWordsFromCollection();
 const wordsByYear = groupWordsByYear(allWords);

--- a/utils/page-metadata-utils.ts
+++ b/utils/page-metadata-utils.ts
@@ -2,13 +2,13 @@ import { format } from 'date-fns';
 
 import type { WordData } from '~types/word';
 import { MONTH_NAMES, monthSlugToNumber } from '~utils/date-utils';
-import { formatWordCount } from '~utils/text-utils';
 import {
   DYNAMIC_STATS_DEFINITIONS,
   LETTER_PATTERN_DEFINITIONS,
   PATTERN_DEFINITIONS,
   STATS_SLUGS,
 } from '~utils/stats-definitions';
+import { formatWordCount } from '~utils/text-utils';
 import {
   getAvailableLengths,
   getAvailableMonths,


### PR DESCRIPTION
## Summary
- enforce import ordering with `eslint-plugin-import`
- reorder imports in pages and utilities for alphabetical grouping
- streamline `getStaticPaths` export in stats page

## Testing
- `npx eslint --fix .` *(fails: Cannot find package '@eslint/js')*
- `npm run lint`
- `npm run typecheck` *(fails: Cannot find module 'astro:content')*
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68964eaef85c832a8a3760bbb41f4466