### PR TITLE
feat: add word list endpoint

### DIFF
--- a/docs/technical.md
+++ b/docs/technical.md
@@ -152,6 +152,10 @@ export const getWordsForYear = (year: string) => getWordsByYear(year, allWords);
 - **Dictionary Validation**: Words must exist in configured dictionary service
 - **Format Validation**: Strict YYYYMMDD date format enforcement
 
+### Word List Endpoint
+A static JSON file is generated at `/words.json` containing an array of word names (strings only).
+Client-side features can fetch this list for random navigation or search without requiring a runtime API.
+
 ## Tools & CLI
 
 ### Unified Tool System

--- a/src/pages/words.json.ts
+++ b/src/pages/words.json.ts
@@ -1,0 +1,18 @@
+import type { APIRoute } from 'astro';
+
+import { allWords } from '~astro-utils/word-data-utils';
+
+/**
+ * Handle word list requests
+ * @returns JSON array of all words
+ */
+export const GET: APIRoute = () => {
+  const wordNames: string[] = allWords.map(({ word }) => word);
+
+  return new Response(JSON.stringify(wordNames), {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+};
+


### PR DESCRIPTION
## Summary
- expose `/words.json` endpoint returning an array of word names
- document lightweight word list endpoint in technical guide

## Testing
- `npm run lint`
- `npx astro sync`
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689feae1389c832aa19d444a55f4e814