### PR TITLE
Fix canonical URL path with base prefix

### DIFF
--- a/src/components/SiteBreadcrumbs.astro
+++ b/src/components/SiteBreadcrumbs.astro
@@ -3,9 +3,7 @@ import SiteLink from '~components/SiteLink.astro';
 import { generateBreadcrumbs } from '~utils/breadcrumb-utils';
 
 const pathname = Astro.url.pathname;
-const basePath = import.meta.env.BASE_PATH;
-
-const breadcrumbs = generateBreadcrumbs(pathname, basePath);
+const breadcrumbs = generateBreadcrumbs(pathname);
 const showBreadcrumbs = breadcrumbs.length > 1;
 ---
 

--- a/src/components/StructuredData.astro
+++ b/src/components/StructuredData.astro
@@ -75,7 +75,7 @@ if (structuredDataType === STRUCTURED_DATA_TYPE.WORD_SINGLE && word) {
 }
 
 // Add breadcrumb schema for non-home pages
-const breadcrumbs = generateBreadcrumbs(Astro.url.pathname, import.meta.env.BASE_PATH);
+const breadcrumbs = generateBreadcrumbs(Astro.url.pathname);
 const breadcrumbSchema = getBreadcrumbSchema(breadcrumbs);
 if (breadcrumbSchema) {
   schemas.push(breadcrumbSchema);

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -11,19 +11,21 @@ import { getBuildData } from '~astro-utils/build-utils.ts';
 import { getSocialImageUrl } from '~astro-utils/image-utils';
 import { getMetaDescription, seoConfig } from '~astro-utils/seo-utils.ts';
 import { getAsciiArt } from '~astro-utils/static-file-utils';
-import { getFullUrl,getUrl } from '~astro-utils/url-utils';
+import { getFullUrl, getUrl, stripBasePath } from '~astro-utils/url-utils';
 import { extractWordDefinition,getWordsFromCollection } from '~astro-utils/word-data-utils';
 import { t } from '~utils/i18n-utils';
 
 const { title, word, description, structuredDataType, noindex, nofollow } = Astro.props;
 
-const currentUrl = getFullUrl(Astro.url.pathname);
+const rawPath = stripBasePath(Astro.url.pathname);
+const currentPath = rawPath === 'home' ? '/' : `/${rawPath}`;
+const currentUrl = getFullUrl(currentPath);
 const pageTitle = title ? `${title} | ${seoConfig.siteName}` : seoConfig.defaultTitle;
 const metaDescription = description || getMetaDescription();
 
 const wordData = word || null;
 const socialImageUrl = getSocialImageUrl({
-  pathname: Astro.url.pathname,
+  pathname: currentPath,
   wordData,
 });
 

--- a/src/utils/image-utils.ts
+++ b/src/utils/image-utils.ts
@@ -1,4 +1,5 @@
 import type { WordData } from '~types';
+import { getUrl } from '~astro-utils/url-utils';
 
 /**
  * Get social media image URL for a word or page
@@ -6,22 +7,20 @@ import type { WordData } from '~types';
  * @returns URL to the social image
  */
 export function getSocialImageUrl({ pathname, wordData }: { pathname: string; wordData?: WordData | null }): string {
-  const basePath = import.meta.env.BASE_PATH || '/';
   const cleanPath = pathname.startsWith('/') ? pathname.slice(1) : pathname;
 
   if (wordData && wordData.word) {
-    // Word-specific social image
-    return `${basePath}images/social/${import.meta.env.SOURCE_DIR || 'demo'}/2025/${wordData.date}-${wordData.word}.png`;
+    return getUrl(
+      `images/social/${import.meta.env.SOURCE_DIR || 'demo'}/2025/${wordData.date}-${wordData.word}.png`,
+    );
   }
 
   if (cleanPath.startsWith('words/')) {
-    // Word path without specific data
     const wordPath = cleanPath.replace('words/', '');
-    return `${basePath}images/social/${import.meta.env.SOURCE_DIR || 'demo'}/2025/${wordPath}.png`;
+    return getUrl(`images/social/${import.meta.env.SOURCE_DIR || 'demo'}/2025/${wordPath}.png`);
   }
 
-  // Generic page social image
-  return `${basePath}images/social/pages/${cleanPath || 'index'}.png`;
+  return getUrl(`images/social/pages/${cleanPath || 'index'}.png`);
 }
 
 /**

--- a/src/utils/url-utils.ts
+++ b/src/utils/url-utils.ts
@@ -7,7 +7,7 @@ import { logger } from '~astro-utils/logger';
  * @returns Normalized URL path
  */
 export const getUrl = (path = '/'): string => {
-  const baseUrl = import.meta.env.BASE_PATH || '/';
+  const baseUrl = import.meta.env.BASE_URL || '/';
 
   if (!path || path === '') {
     return baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
@@ -66,7 +66,7 @@ export const getWordUrl = (word: string): string => {
  * @returns Pathname relative to the site root
  */
 export const stripBasePath = (pathname: string): string => {
-  const base = (import.meta.env.BASE_PATH || '').replace(/\/+$/, '');
+  const base = (import.meta.env.BASE_URL || '').replace(/\/+$/, '');
   const hasBase = base && pathname.toLowerCase().startsWith(base.toLowerCase());
   const withoutBase = hasBase ? pathname.slice(base.length) : pathname;
   const clean = withoutBase.replace(/^\/+|\/+$/g, '');

--- a/tests/src/components/WordLink.spec.js
+++ b/tests/src/components/WordLink.spec.js
@@ -10,11 +10,11 @@ import { getUrl, getWordUrl } from '~astro-utils/url-utils';
 
 describe('WordLink Component Integration', () => {
   beforeEach(() => {
-    vi.stubEnv('BASE_PATH', '/');
+    vi.stubEnv('BASE_URL', '/');
   });
 
   describe('getWordUrl', () => {
-    it('should return relative path without BASE_PATH processing', () => {
+    it('should return relative path without BASE_URL processing', () => {
       expect(getWordUrl('serendipity')).toBe('/words/serendipity');
       expect(getWordUrl('ice cream')).toBe('/words/ice cream');
     });
@@ -23,15 +23,15 @@ describe('WordLink Component Integration', () => {
       expect(getWordUrl('')).toBe('');
     });
 
-    it('should work regardless of BASE_PATH', () => {
-      vi.stubEnv('BASE_PATH', '/occasional-wotd');
+    it('should work regardless of BASE_URL', () => {
+      vi.stubEnv('BASE_URL', '/occasional-wotd');
       expect(getWordUrl('test')).toBe('/words/test');
     });
   });
 
   describe('WordLink + SiteLink integration flow', () => {
-    it('should prevent double BASE_PATH with no subdirectory', () => {
-      vi.stubEnv('BASE_PATH', '/');
+    it('should prevent double BASE_URL with no subdirectory', () => {
+      vi.stubEnv('BASE_URL', '/');
 
       const rawPath = getWordUrl('serendipity');
       const processedUrl = getUrl(rawPath);
@@ -40,8 +40,8 @@ describe('WordLink Component Integration', () => {
       expect(processedUrl).toBe('/words/serendipity');
     });
 
-    it('should prevent double BASE_PATH with subdirectory', () => {
-      vi.stubEnv('BASE_PATH', '/occasional-wotd');
+    it('should prevent double BASE_URL with subdirectory', () => {
+      vi.stubEnv('BASE_URL', '/occasional-wotd');
 
       const rawPath = getWordUrl('serendipity');
       const processedUrl = getUrl(rawPath);
@@ -52,7 +52,7 @@ describe('WordLink Component Integration', () => {
     });
 
     it('should handle multi-word phrases correctly', () => {
-      vi.stubEnv('BASE_PATH', '/occasional-wotd');
+      vi.stubEnv('BASE_URL', '/occasional-wotd');
 
       const rawPath = getWordUrl('ice cream');
       const processedUrl = getUrl(rawPath);
@@ -62,7 +62,7 @@ describe('WordLink Component Integration', () => {
     });
 
     it('should handle special characters in words', () => {
-      vi.stubEnv('BASE_PATH', '/occasional-wotd');
+      vi.stubEnv('BASE_URL', '/occasional-wotd');
 
       const rawPath = getWordUrl("don't");
       const processedUrl = getUrl(rawPath);
@@ -74,7 +74,7 @@ describe('WordLink Component Integration', () => {
 
   describe('Real-world GitHub Pages scenarios', () => {
     it('should match expected GitHub Pages URLs', () => {
-      vi.stubEnv('BASE_PATH', '/occasional-wotd');
+      vi.stubEnv('BASE_URL', '/occasional-wotd');
 
         const testCases = [
           { word: 'serendipity', expected: '/occasional-wotd/words/serendipity' },
@@ -91,7 +91,7 @@ describe('WordLink Component Integration', () => {
     });
 
     it('should work correctly for localhost development', () => {
-      vi.stubEnv('BASE_PATH', '/');
+      vi.stubEnv('BASE_URL', '/');
 
       const rawPath = getWordUrl('test');
       const processedUrl = getUrl(rawPath);

--- a/tests/utils/breadcrumb-utils.spec.js
+++ b/tests/utils/breadcrumb-utils.spec.js
@@ -1,8 +1,8 @@
-import { describe, it, expect, vi } from 'vitest';
-import { generateBreadcrumbs } from '../../utils/breadcrumb-utils';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { generateBreadcrumbs } from '~utils/breadcrumb-utils';
 
 // Mock the page metadata utility
-vi.mock('../../utils/page-metadata-utils', () => ({
+vi.mock('~utils/page-metadata-utils', () => ({
   getPageMetadata: vi.fn((path) => {
     const metadataMap = {
       '/words': { title: 'All Words' },
@@ -20,6 +20,9 @@ vi.mock('../../utils/page-metadata-utils', () => ({
 }));
 
 describe('generateBreadcrumbs', () => {
+  beforeEach(() => {
+    vi.stubEnv('BASE_URL', '/');
+  });
   it('should return empty array for home page', () => {
     expect(generateBreadcrumbs('/')).toEqual([]);
     expect(generateBreadcrumbs('')).toEqual([]);
@@ -53,12 +56,14 @@ describe('generateBreadcrumbs', () => {
   });
 
   it('should handle base path correctly', () => {
-    const result = generateBreadcrumbs('/blog/words/hello', '/blog');
+    vi.stubEnv('BASE_URL', '/blog');
+    const result = generateBreadcrumbs('/blog/words/hello');
     expect(result).toEqual([
       { label: 'home', href: '/' },
       { label: 'all words', href: '/words' },
       { label: 'hello', href: '/words/hello' }
     ]);
+    vi.stubEnv('BASE_URL', '/');
   });
 
   it('should handle letter browsing pages', () => {

--- a/tests/utils/page-metadata-utils.spec.js
+++ b/tests/utils/page-metadata-utils.spec.js
@@ -161,8 +161,8 @@ describe('page-metadata-utils', () => {
   });
 
   describe('getPageMetadata wrapper', () => {
-    it('handles BASE_PATH prefixes', async () => {
-      vi.stubEnv('BASE_PATH', '/vocab');
+    it('handles BASE_URL prefixes', async () => {
+      vi.stubEnv('BASE_URL', '/vocab');
       const { getPageMetadata: getPageMetadataWrapper } = await import(
         '~astro-utils/page-metadata'
       );
@@ -175,8 +175,8 @@ describe('page-metadata-utils', () => {
       });
     });
 
-    it('handles BASE_PATH with different case and trailing slash', async () => {
-      vi.stubEnv('BASE_PATH', '/Vocab/');
+    it('handles BASE_URL with different case and trailing slash', async () => {
+      vi.stubEnv('BASE_URL', '/Vocab/');
       vi.resetModules();
       const { getPageMetadata: getPageMetadataWrapper } = await import(
         '~astro-utils/page-metadata'

--- a/tests/utils/url-utils.spec.js
+++ b/tests/utils/url-utils.spec.js
@@ -19,7 +19,7 @@ import {
 describe('utils', () => {
   describe('getUrl', () => {
     beforeEach(() => {
-      vi.stubEnv('BASE_PATH', '/');
+      vi.stubEnv('BASE_URL', '/');
     });
 
     it('handles paths with default base path', () => {
@@ -27,17 +27,17 @@ describe('utils', () => {
     });
 
     it('handles paths with custom base path', () => {
-      vi.stubEnv('BASE_PATH', '/blog');
+      vi.stubEnv('BASE_URL', '/blog');
       expect(getUrl('/20240319')).toBe('/blog/20240319');
     });
 
     it('handles paths with custom base path with trailing slash', () => {
-      vi.stubEnv('BASE_PATH', '/blog/');
+      vi.stubEnv('BASE_URL', '/blog/');
       expect(getUrl('/20240319')).toBe('/blog/20240319');
     });
 
     it('handles empty or undefined base path', () => {
-      vi.stubEnv('BASE_PATH', '');
+      vi.stubEnv('BASE_URL', '');
       expect(getUrl('/20240319')).toBe('/20240319');
     });
 
@@ -62,20 +62,20 @@ describe('utils', () => {
     });
 
     it('ignores SITE_URL when building relative URLs', () => {
-      vi.stubEnv('BASE_PATH', '/blog');
+      vi.stubEnv('BASE_URL', '/blog');
       vi.stubEnv('SITE_URL', 'https://example.com');
       expect(getUrl('/words/hello')).toBe('/blog/words/hello');
     });
 
     it('preserves case for base path and path', () => {
-      vi.stubEnv('BASE_PATH', '/Blog');
+      vi.stubEnv('BASE_URL', '/Blog');
       expect(getUrl('/ABC')).toBe('/Blog/ABC');
     });
   });
 
   describe('getFullUrl', () => {
     beforeEach(() => {
-      vi.stubEnv('BASE_PATH', '/');
+      vi.stubEnv('BASE_URL', '/');
       vi.stubEnv('SITE_URL', 'https://example.com');
     });
 
@@ -84,7 +84,7 @@ describe('utils', () => {
     });
 
     it('handles subdirectory deployments correctly', () => {
-      vi.stubEnv('BASE_PATH', '/vocab');
+      vi.stubEnv('BASE_URL', '/vocab');
       expect(getFullUrl('/words/hello')).toBe('https://example.com/vocab/words/hello');
     });
 

--- a/utils/breadcrumb-utils.ts
+++ b/utils/breadcrumb-utils.ts
@@ -3,7 +3,8 @@
  * Generates breadcrumb navigation data from URL pathnames
  */
 
-import { getPageMetadata } from './page-metadata-utils';
+import { getPageMetadata } from '~utils/page-metadata-utils';
+import { stripBasePath } from '~astro-utils/url-utils';
 
 export interface BreadcrumbItem {
   label: string;
@@ -13,28 +14,16 @@ export interface BreadcrumbItem {
 /**
  * Generate breadcrumb items from a URL pathname
  * @param pathname - The URL pathname to parse
- * @param basePath - The base path to filter out (e.g., from BASE_PATH env var)
  * @returns Array of breadcrumb items with labels and hrefs
  */
-export function generateBreadcrumbs(pathname: string, basePath?: string): BreadcrumbItem[] {
-  // Clean the pathname - remove leading/trailing slashes
-  const cleanPath = pathname.replace(/^\/|\/$/g, '');
-  
-  // Remove base path if provided
-  const pathWithoutBase = basePath && basePath !== '/' 
-    ? cleanPath.replace(new RegExp(`^${basePath.replace(/^\/|\/$/g, '')}`), '').replace(/^\//, '')
-    : cleanPath;
-  
-  // Return empty array for home page
-  if (!pathWithoutBase) {
+export function generateBreadcrumbs(pathname: string): BreadcrumbItem[] {
+  const pathWithoutBase = stripBasePath(pathname);
+
+  if (!pathWithoutBase || pathWithoutBase === 'home') {
     return [];
   }
-  
+
   const segments = pathWithoutBase.split('/').filter(Boolean);
-  
-  if (segments.length === 0) {
-    return [];
-  }
   
   // Build breadcrumbs progressively
   const breadcrumbs: BreadcrumbItem[] = [


### PR DESCRIPTION
## Summary
- normalize current path by stripping base before generating canonical link
- build social image URLs from base-stripped path

## Testing
- `npm run lint`
- `npx astro sync`
- `npm run typecheck`
- `npm test`
- `BASE_PATH=/occasional-wotd/ SITE_URL=https://seriouslysean.github.io npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0b6c2efe0832a97c3860a4666778f