### PR TITLE
fix: use full mobile width for the word display

### DIFF
--- a/src/components/Heading.astro
+++ b/src/components/Heading.astro
@@ -39,7 +39,7 @@ const headingClass = preserveCase ? 'heading__text preserve-case' : 'heading__te
         color: transparent;
         letter-spacing: -0.02em;
         display: inline-block;
-        padding: 0 var(--spacing-small);
+        padding: 0;
         word-break: break-word;
         hyphens: auto;
         filter: drop-shadow(0 2px 0px rgba(0, 0, 0, 0.5))

--- a/src/components/Word.astro
+++ b/src/components/Word.astro
@@ -35,7 +35,6 @@ const { partOfSpeech, definition, meta } = getWordDetails(word);
         width: 100%;
         max-width: var(--content-width-full);
         margin: 0 auto;
-        padding: 0 var(--spacing-base);
     }
 
     .word__date {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -176,7 +176,9 @@ const wordSchemaData = word ? (() => {
 	.content {
 		flex: 1;
 		width: 100%;
-		max-width: var(--content-width-large);
+		/* Full width (minus the padding margin) on phones and tablets;
+		   the centered max-width column kicks in at the desktop breakpoint. */
+		max-width: 100%;
 		margin: 0 auto;
 		padding: 1rem var(--spacing-base);
 	}
@@ -207,6 +209,7 @@ const wordSchemaData = word ? (() => {
 
 	@media (min-width: 1025px) {
 		.content {
+			max-width: var(--content-width-large);
 			padding: 2rem var(--spacing-base);
 		}
 	}


### PR DESCRIPTION
## Summary

On phones the word title was capped to ~74% of the viewport — the content column's 90vw cap plus stacked content/word/heading horizontal padding — so medium words wrapped (e.g. `occasional` broke to `occasion-al`) with side whitespace.

- Make `.content` full width (minus its padding margin) below the 1025px desktop breakpoint; restore the centered `max-width` column at desktop (unchanged there).
- Drop the now-redundant horizontal padding on `.word` and the heading text, which duplicated the content padding.

Result on a 390px viewport: medium words fit on one line and fill the width with a margin; the longest word (`pneumonoultramicroscopicsilicovolcanoconiosis`, 45 chars) fills the width and wraps across 6 **readable** lines — it stays at the clamp size (59px), not shrunk to fit. The change is site-wide on mobile/tablet, so browse/stats titles and lists are fuller too; no horizontal overflow on any page checked. Desktop is unchanged.

Pure CSS, no JavaScript — a true fit-to-width (which would fill every word) was rejected because the 1–45 char range makes it unworkable: `a` would render ~655px and the 45-char word ~15px.

## Test plan

- [x] Quality gates pass (lint, typecheck, test, build) — 0 lint, astro check 0/0/0, 511 tests, build clean, e2e 14/14
- [x] Relevant tests added or updated — N/A (CSS-only layout change; covered by existing e2e)
- [x] Manual verification if applicable — measured + screenshotted at 390px (word medium + 45-char, browse, stats: no overflow) and 1280px (desktop unchanged)
