### PR TITLE
fix: dismiss the header search when clicking outside it

### DIFF
--- a/src/components/HeaderSearch.astro
+++ b/src/components/HeaderSearch.astro
@@ -124,6 +124,19 @@ document.addEventListener('keydown', event => {
     toggle?.focus();
   }
 });
+
+// Tapping or clicking anywhere outside the search (toggle, field, results)
+// dismisses the open panel. Clicks inside keep it open; the toggle's own
+// handler manages reopening. No refocus -- the pointer already moved away.
+document.addEventListener('click', event => {
+  if (panel?.hidden) {
+    return;
+  }
+  const target = event.target as Element | null;
+  if (!target?.closest('.site-search')) {
+    closePanel();
+  }
+});
 </script>
 
 <style>

--- a/tests/e2e/search.spec.ts
+++ b/tests/e2e/search.spec.ts
@@ -37,6 +37,18 @@ test.describe('header search', () => {
     await expect(page.locator('#site-search-results a')).toHaveCount(0);
   });
 
+  test('closes when clicking outside the search', async ({ page }) => {
+    await page.goto('/');
+    await page.locator('#site-search-toggle').click();
+
+    const input = page.locator('#site-search-input');
+    await expect(input).toBeVisible();
+
+    // A click outside the search container (the footer) dismisses the panel.
+    await page.locator('footer').click();
+    await expect(input).toBeHidden();
+  });
+
   test('the search icon is hidden without JavaScript', async ({ browser }) => {
     const context = await browser.newContext({ javaScriptEnabled: false });
     const page = await context.newPage();


### PR DESCRIPTION
## Summary

- The open header-search panel now dismisses when the user clicks or taps anywhere outside the search container. Clicks on the toggle, input, and results keep it open; the toggle's own handler still manages reopening.
- Implemented as a `document` click listener alongside the existing Escape handler in `HeaderSearch.astro`. No refocus on outside-click, since the pointer has already moved away (Escape still refocuses the toggle for keyboard users).

## Test plan

- [x] Quality gates pass (lint, typecheck, test, build)
- [x] Relevant tests added or updated
- [x] Manual verification if applicable