### PR TITLE
fix: heatmap tooltip opacity, Monday-first week, outlined out-of-year cells

### DIFF
--- a/src/components/CalendarHeatmap.astro
+++ b/src/components/CalendarHeatmap.astro
@@ -49,7 +49,7 @@ const calendars = buildActivityCalendar(entries.map(entry => entry.date)).toReve
               )
               : (
                 <span
-                  class="heatmap__cell"
+                  class:list={['heatmap__cell', { 'heatmap__cell--padding': !cell.date }]}
                   title={cell.date ? formatDate(cell.date) : undefined}
                 ></span>
               );
@@ -98,12 +98,18 @@ const calendars = buildActivityCalendar(entries.map(entry => entry.date)).toReve
     aspect-ratio: 54 / 7;
   }
 
-  /* Non-active cells (empty in-year days and leading/trailing padding) are faint
-     squares; active days fill solid and link to that day's word. */
+  /* Empty in-year days are faint filled squares; leading/trailing padding (cells
+     outside the year) is the same grey but outlined, not filled, so it reads as
+     "not part of this year"; active days fill solid and link out. */
   .heatmap__cell {
     border-radius: 2px;
     background: var(--color-border);
     opacity: 0.5;
+  }
+
+  .heatmap__cell--padding {
+    background: transparent;
+    box-shadow: inset 0 0 0 1px var(--color-border);
   }
 
   .heatmap__cell--active {
@@ -114,8 +120,11 @@ const calendars = buildActivityCalendar(entries.map(entry => entry.date)).toReve
     transition: var(--transition);
   }
 
+  /* Fade the square to ~50% on hover via a transparent background, not opacity:
+     element opacity would also fade the tooltip (a child of this cell), since
+     group opacity applies to the whole subtree. color-mix fades just the fill. */
   .heatmap__cell--active:hover {
-    opacity: 0.7;
+    background: color-mix(in srgb, var(--color-primary) 50%, transparent);
   }
 
   .heatmap__cell--active:focus-visible {

--- a/tests/utils/calendar-utils.spec.js
+++ b/tests/utils/calendar-utils.spec.js
@@ -17,10 +17,15 @@ describe('calendar-utils', () => {
       expect(year2023.cells.filter(cell => cell.date).length).toBe(365);
     });
 
-    it('pads leading cells so Jan 1 lands on its weekday', () => {
+    it('pads leading cells so Jan 1 lands on its weekday (Monday-first week)', () => {
+      // Jan 1 2023 is a Sunday -> 6 leading cells (Mon-Sat) before it.
+      const [year2023] = buildActivityCalendar(['20230101']);
+      const leading2023 = year2023.cells.filter((cell, index) => cell.date === null && index < 7).length;
+      expect(leading2023).toBe(6);
+      // Jan 1 2024 is a Monday -> it lands on the first row, no leading cells.
       const [year2024] = buildActivityCalendar(['20240101']);
-      const leading = year2024.cells.filter((cell, index) => cell.date === null && index < 7).length;
-      expect(leading).toBe(new Date(2024, 0, 1).getDay());
+      const leading2024 = year2024.cells.filter((cell, index) => cell.date === null && index < 7).length;
+      expect(leading2024).toBe(0);
     });
 
     it('marks active days and totals them', () => {

--- a/utils/calendar-utils.ts
+++ b/utils/calendar-utils.ts
@@ -36,8 +36,10 @@ export const buildActivityCalendar = (dates: string[]): YearActivity[] => {
     const cells: ActivityCell[] = [];
     const yearNum = Number(year);
 
-    // Pad so Jan 1 lands on its real weekday (0 = Sunday) in the first column.
-    const leadingDays = new Date(yearNum, 0, 1).getDay();
+    // Monday-first week: pad so Jan 1 lands on its weekday. getDay() is
+    // 0 = Sunday, so remap to Monday = 0 .. Sunday = 6 (a Sunday Jan 1 gets 6
+    // leading padding cells, landing it on the last row).
+    const leadingDays = (new Date(yearNum, 0, 1).getDay() + 6) % 7;
     for (let i = 0; i < leadingDays; i++) {
       cells.push({ date: null, active: false });
     }


### PR DESCRIPTION
## Summary

- **Opaque hover tooltip**: the tooltip is a child of the cell, so the cell's hover `opacity` faded the tooltip too (group opacity applies to the whole subtree). The square now fades on hover via a transparent `background` (`color-mix`), leaving the tooltip solid. (Supersedes the incomplete v3.20.0 fix, which changed the wrong element.)
- **Monday-first week**: remap `getDay()` so a year whose Jan 1 is a Sunday (e.g. 2023) no longer starts flush in the top-left — Jan 1 lands on its real weekday row with leading padding before it.
- **Out-of-year padding**: leading/trailing padding cells render as outlined grey squares (not faint fills), so they read as not-part-of-this-year and are distinct from in-year days with no word.

## Test plan

- [x] Quality gates pass (lint, typecheck, test, build)
- [x] Relevant tests added or updated (calendar-utils week-start)
- [x] Manual verification if applicable