### PR TITLE
fix: enforce vitest coverage thresholds

### DIFF
--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,4 +1,4 @@
-import { vi } from 'vitest';
+import { afterEach, vi } from 'vitest';
 import mockTranslations from '#tests/locales/en-us.fixtures.json';
 
 // Mock astro:env/client with mutable defaults for all tests
@@ -39,6 +39,15 @@ vi.mock('astro:env/client', () => mockEnv);
 
 // Expose for tests that need to override env values
 global.mockEnv = mockEnv;
+
+// vitest runs with `isolate: false`, so test files share this mockEnv object
+// and the module registry. Tests that override BASE_PATH (url-utils,
+// WordLink, the page-metadata wrapper) would otherwise leak the value into
+// whichever file runs next, causing order-dependent failures. Restore the
+// default after every test so each starts from a clean BASE_PATH.
+afterEach(() => {
+  mockEnv.BASE_PATH = '/';
+});
 
 // Mock fixture data for testing
 const mockWordData = [

--- a/tests/utils/page-metadata-utils.spec.js
+++ b/tests/utils/page-metadata-utils.spec.js
@@ -202,6 +202,9 @@ describe('page-metadata-utils', () => {
   describe('getPageMetadata wrapper', () => {
     it('handles BASE_PATH prefixes', async () => {
       mockEnv.BASE_PATH = '/vocab';
+      // Reset modules so the wrapper re-reads BASE_PATH instead of a value
+      // cached by an earlier test file (the suite runs files in parallel).
+      vi.resetModules();
       const { getPageMetadata: getPageMetadataWrapper } = await import(
         '#astro-utils/page-metadata'
       );

--- a/tests/utils/page-metadata-utils.spec.js
+++ b/tests/utils/page-metadata-utils.spec.js
@@ -33,7 +33,12 @@ vi.mock('#utils/i18n-utils', () => ({
   tp: vi.fn((baseKey, count) => `${count} Mock Items`)
 }));
 
-import { getAllPageMetadata, getPageMetadata } from '#utils/page-metadata-utils';
+import {
+  getAllPageMetadata,
+  getDefinition,
+  getPageMetadata,
+  getPageTitle,
+} from '#utils/page-metadata-utils';
 
 // Clean up mock after this test file to prevent leakage to other tests
 afterAll(() => {
@@ -221,6 +226,95 @@ describe('page-metadata-utils', () => {
         description: 'Mock stats description',
         category: 'pages',
         secondaryText: 'Mock Stats Subheading',
+      });
+    });
+  });
+
+  describe('getDefinition', () => {
+    it('returns the value for an existing key', () => {
+      expect(getDefinition({ a: 1, b: 2 }, 'b')).toBe(2);
+    });
+
+    it('throws for a missing key', () => {
+      expect(() => getDefinition({ a: 1 }, 'missing')).toThrow(
+        'Missing definition for key: missing',
+      );
+    });
+  });
+
+  describe('getPageTitle', () => {
+    it('returns Unknown Page for an empty path', () => {
+      expect(getPageTitle('')).toBe('Unknown Page');
+    });
+
+    it('returns the static title for a known path', () => {
+      expect(getPageTitle('/word')).toBe('Mock Words Heading');
+    });
+
+    it('returns the word for a word-detail path', () => {
+      expect(getPageTitle('/word/example')).toBe('example');
+    });
+
+    it('returns the year for a year path', () => {
+      expect(getPageTitle('/browse/2024')).toBe('2024');
+    });
+
+    it('returns the capitalized month name for a month path', () => {
+      expect(getPageTitle('/browse/2024/january')).toBe('January');
+    });
+
+    it('returns the length-words title for a length path', () => {
+      expect(getPageTitle('/browse/length/5')).toBe('5-Letter Words');
+    });
+
+    it('returns the uppercased letter for a letter path', () => {
+      expect(getPageTitle('/browse/letter/a')).toBe('A');
+    });
+
+    it('returns the part-of-speech name for a part-of-speech path', () => {
+      expect(getPageTitle('/browse/part-of-speech/noun')).toBe('Noun');
+    });
+
+    it('returns Unknown Page for a month path with an unknown month slug', () => {
+      expect(getPageTitle('/browse/2024/notamonth')).toBe('Unknown Page');
+    });
+
+    it('returns Unknown Page for an unrecognized path', () => {
+      expect(getPageTitle('/totally/unknown')).toBe('Unknown Page');
+    });
+  });
+
+  describe('getPageMetadata dynamic paths', () => {
+    it('returns metadata for a word-detail page', () => {
+      expect(getPageMetadata('/word/example', mockWords)).toEqual({
+        title: 'example',
+        description: 'Definition and meaning of example.',
+        category: 'pages',
+      });
+    });
+
+    it('returns metadata for a part-of-speech page', () => {
+      const metadata = getPageMetadata('/browse/part-of-speech/noun', mockWords);
+      expect(metadata.title).toBe('Noun');
+      expect(metadata.category).toBe('pages');
+      expect(metadata.description).toContain('noun');
+      expect(metadata.secondaryText).toBe('0 Mock Items');
+    });
+
+    it('returns home metadata for the root path', () => {
+      const metadata = getPageMetadata('/', mockWords);
+      expect(metadata.title).toBe('Mock Home Heading');
+      expect(metadata.category).toBe('pages');
+      expect(typeof metadata.description).toBe('string');
+      expect(metadata.secondaryText).toBeUndefined();
+    });
+
+    it('falls back to Unknown Page for a month path with an unknown month slug', () => {
+      expect(getPageMetadata('/browse/2024/notamonth', mockWords)).toEqual({
+        title: 'Unknown Page',
+        description: '',
+        category: 'unknown',
+        secondaryText: undefined,
       });
     });
   });

--- a/tests/utils/word-stats-utils.spec.js
+++ b/tests/utils/word-stats-utils.spec.js
@@ -1,13 +1,22 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  findWordDate,
+  getAntiStreakStats,
   getChronologicalMilestones,
+  getCurrentStreakStats,
+  getCurrentStreakWords,
   getLetterPatternStats,
   getLetterStats,
+  getLetterStatsFromFrequency,
+  getLetterTypeStats,
+  getLongestStreakWords,
   getPatternStats,
+  getSyllableStats,
   getWordEndingStats,
+  getWordStats,
 } from '#utils/word-stats-utils';
-import { areConsecutiveDays } from '#utils/date-utils';
+import { areConsecutiveDays, dateToYYYYMMDD } from '#utils/date-utils';
 
 const sampleWords = [
   { word: 'hello', date: '20240101' },
@@ -169,6 +178,231 @@ describe('word-stats-utils', () => {
       expect(milestones.find(m => m.milestone === 75)).toBeDefined();
       expect(milestones.find(m => m.milestone === 100)).toBeDefined();
       expect(milestones.find(m => m.milestone === 200)).toBeDefined();
+    });
+  });
+
+  describe('getLetterPatternStats triple letters', () => {
+    it('captures words with three consecutive identical letters', () => {
+      const patterns = getLetterPatternStats([{ word: 'aaah', date: '20240101' }]);
+      expect(patterns.tripleLetters).toContainEqual({ word: 'aaah', date: '20240101' });
+    });
+  });
+
+  describe('getWordStats', () => {
+    it('returns empty stats for an empty array', () => {
+      expect(getWordStats([])).toEqual({
+        longest: null,
+        shortest: null,
+        longestPalindrome: null,
+        shortestPalindrome: null,
+        letterFrequency: {},
+      });
+    });
+
+    it('finds the longest, shortest, and palindrome extremes', () => {
+      const words = [
+        { word: 'cat', date: '20240101' },
+        { word: 'elephant', date: '20240102' },
+        { word: 'deed', date: '20240103' },
+        { word: 'level', date: '20240104' },
+        { word: 'a', date: '20240105' },
+      ];
+      const stats = getWordStats(words);
+      expect(stats.longest.word).toBe('elephant');
+      expect(stats.shortest.word).toBe('a');
+      expect(stats.longestPalindrome.word).toBe('level');
+      expect(stats.shortestPalindrome.word).toBe('a');
+      expect(stats.letterFrequency.e).toBeGreaterThan(0);
+    });
+  });
+
+  describe('getSyllableStats', () => {
+    it('returns null extremes for an empty array', () => {
+      expect(getSyllableStats([])).toEqual({ mostSyllables: null, leastSyllables: null });
+    });
+
+    it('finds the words with the most and least syllables', () => {
+      const words = [
+        { word: 'monkey', date: '20240101' },
+        { word: 'banana', date: '20240102' },
+        { word: 'cat', date: '20240103' },
+      ];
+      const stats = getSyllableStats(words);
+      expect(stats.mostSyllables.word).toBe('banana');
+      expect(stats.leastSyllables.word).toBe('cat');
+    });
+  });
+
+  describe('getLetterTypeStats', () => {
+    it('returns null extremes for an empty array', () => {
+      expect(getLetterTypeStats([])).toEqual({ mostVowels: null, mostConsonants: null });
+    });
+
+    it('finds the words with the most vowels and most consonants', () => {
+      const words = [
+        { word: 'cat', date: '20240101' },
+        { word: 'aeiou', date: '20240102' },
+        { word: 'strength', date: '20240103' },
+      ];
+      const stats = getLetterTypeStats(words);
+      expect(stats.mostVowels.word).toBe('aeiou');
+      expect(stats.mostConsonants.word).toBe('strength');
+    });
+  });
+
+  describe('findWordDate', () => {
+    const words = [
+      { word: 'cat', date: '20240101' },
+      { word: 'dog', date: '20240102' },
+    ];
+
+    it('returns undefined for an empty target', () => {
+      expect(findWordDate(words, '')).toBeUndefined();
+    });
+
+    it('returns the date for a matching word', () => {
+      expect(findWordDate(words, 'dog')).toBe('20240102');
+    });
+
+    it('returns undefined when the word is not present', () => {
+      expect(findWordDate(words, 'fish')).toBeUndefined();
+    });
+  });
+
+  describe('getLetterStatsFromFrequency', () => {
+    it('returns an empty array for an empty frequency map', () => {
+      expect(getLetterStatsFromFrequency({})).toEqual([]);
+    });
+
+    it('returns letter entries sorted by descending count, filtering non-letters', () => {
+      const sorted = getLetterStatsFromFrequency({ a: 5, b: 3, '1': 9 });
+      expect(sorted).toEqual([['a', 5], ['b', 3]]);
+    });
+  });
+
+  describe('getLongestStreakWords', () => {
+    it('returns the input unchanged for length <= 1', () => {
+      expect(getLongestStreakWords([])).toEqual([]);
+      const one = [{ word: 'solo', date: '20240101' }];
+      expect(getLongestStreakWords(one)).toEqual(one);
+    });
+
+    it('returns the longest consecutive run in chronological order', () => {
+      const words = [
+        { word: 'a', date: '20240101' },
+        { word: 'b', date: '20240102' },
+        { word: 'c', date: '20240103' },
+        { word: 'gap', date: '20240110' },
+        { word: 'd', date: '20240111' },
+      ];
+      expect(getLongestStreakWords(words).map(w => w.word)).toEqual(['a', 'b', 'c']);
+    });
+  });
+
+  describe('getAntiStreakStats', () => {
+    it('returns an empty result for <= 1 word', () => {
+      expect(getAntiStreakStats([])).toEqual({
+        longestGap: 0,
+        gapStartWord: null,
+        gapEndWord: null,
+        gapStartDate: null,
+        gapEndDate: null,
+      });
+      expect(getAntiStreakStats([{ word: 'solo', date: '20240101' }]).longestGap).toBe(0);
+    });
+
+    it('finds the longest gap between consecutive word dates', () => {
+      const words = [
+        { word: 'a', date: '20240101' },
+        { word: 'b', date: '20240103' },
+        { word: 'c', date: '20240110' },
+      ];
+      const result = getAntiStreakStats(words);
+      expect(result.longestGap).toBe(6);
+      expect(result.gapStartWord.word).toBe('b');
+      expect(result.gapEndWord.word).toBe('c');
+      expect(result.gapStartDate).toBe('20240103');
+      expect(result.gapEndDate).toBe('20240110');
+    });
+  });
+
+  describe('streak helpers (time-sensitive)', () => {
+    const BASE = new Date('2024-06-15T12:00:00Z');
+    const offset = (n) => {
+      const d = new Date(BASE);
+      d.setDate(d.getDate() + n);
+      return dateToYYYYMMDD(d);
+    };
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(BASE);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    describe('getCurrentStreakWords', () => {
+      it('returns [] for an empty array', () => {
+        expect(getCurrentStreakWords([])).toEqual([]);
+      });
+
+      it('returns [] when the most recent word is neither today nor yesterday', () => {
+        expect(getCurrentStreakWords([{ word: 'old', date: offset(-10) }])).toEqual([]);
+      });
+
+      it('collects consecutive words ending today, stopping at the first gap', () => {
+        const words = [
+          { word: 'd0', date: offset(0) },
+          { word: 'd1', date: offset(-1) },
+          { word: 'd2', date: offset(-2) },
+          { word: 'gap', date: offset(-5) },
+        ];
+        expect(getCurrentStreakWords(words).map(w => w.word)).toEqual(['d0', 'd1', 'd2']);
+      });
+    });
+
+    describe('getCurrentStreakStats', () => {
+      it('returns zeros for an empty array', () => {
+        expect(getCurrentStreakStats([])).toEqual({
+          currentStreak: 0,
+          longestStreak: 0,
+          isActive: false,
+        });
+      });
+
+      it('reports a single active word', () => {
+        expect(getCurrentStreakStats([{ word: 'solo', date: offset(0) }])).toEqual({
+          currentStreak: 1,
+          longestStreak: 1,
+          isActive: true,
+        });
+      });
+
+      it('computes current and longest streaks across a gap', () => {
+        const words = [
+          { word: 'd0', date: offset(0) },
+          { word: 'd1', date: offset(-1) },
+          { word: 'gap', date: offset(-4) },
+          { word: 'g1', date: offset(-5) },
+          { word: 'g2', date: offset(-6) },
+        ];
+        const stats = getCurrentStreakStats(words);
+        expect(stats.isActive).toBe(true);
+        expect(stats.currentStreak).toBe(2);
+        expect(stats.longestStreak).toBe(3);
+      });
+
+      it('reports inactive with no current streak when the most recent word is stale', () => {
+        const stats = getCurrentStreakStats([
+          { word: 'old', date: offset(-10) },
+          { word: 'older', date: offset(-11) },
+        ]);
+        expect(stats.isActive).toBe(false);
+        expect(stats.currentStreak).toBe(0);
+        expect(stats.longestStreak).toBe(2);
+      });
     });
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -30,12 +30,10 @@ export default defineConfig({
       ],
       thresholds: {
         autoUpdate: false,
-        global: {
-          branches: 85,
-          functions: 80,
-          lines: 80,
-          statements: 80,
-        },
+        branches: 85,
+        functions: 80,
+        lines: 80,
+        statements: 80,
       },
     },
   },


### PR DESCRIPTION
## Summary

- The coverage thresholds in `vitest.config.ts` were nested under a `global:` key, which is Jest's shape, but vitest reads them directly under `thresholds` and treats `global` as a glob matching no files, so the 85% branch / 80% line check had silently never run: branch coverage sat at 76.5% and the suite still passed green. Hoists the four thresholds up to where vitest actually reads them.
- To clear the now-live 85% branch check, added tests for functions that had none: `word-stats-utils` (current/longest streaks via fake timers, syllable and letter-type extremes, anti-streak gaps, word stats) and `page-metadata-utils` (`getPageTitle`, `getDefinition`, and the word/part-of-speech/home/unknown-month dynamic paths). Branch coverage is now 87%.

## Test plan

- [x] Quality gates pass (lint, typecheck, test, build)
- [x] Relevant tests added or updated (39 new cases across the two spec files)
- [x] Manual verification: confirmed the threshold now fails the run when branch coverage drops below it (the misnested config let any level pass before)
