### PR TITLE
fix: isolate generate-images test output to a temp dir

### DIFF
--- a/config/paths.ts
+++ b/config/paths.ts
@@ -18,6 +18,13 @@ const getWordsPath = (): string => {
 };
 
 const getImagesPath = (): string => {
+  // Redirect generated-image output when set (tests point this at a temp dir
+  // so image generation never overwrites tracked social cards under public/).
+  const outputOverride = process.env.IMAGES_OUTPUT_DIR;
+  if (outputOverride) {
+    return outputOverride;
+  }
+
   const sourceDir = process.env.SOURCE_DIR;
   return sourceDir
     ? path.join(ROOT, 'public', sourceDir, 'images')

--- a/tests/tools/cli-integration.spec.js
+++ b/tests/tools/cli-integration.spec.js
@@ -19,6 +19,7 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { spawnTool } from '#tests/helpers/spawn';
 
@@ -188,16 +189,30 @@ describe('CLI Tools: Basic Functionality', () => {
     const wordData = JSON.parse(fs.readFileSync(firstWordFile, 'utf-8'));
     const testWord = wordData.word;
 
+    // Redirect output to a throwaway temp dir so generation never overwrites
+    // the tracked demo social cards under public/.
+    const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wotd-images-'));
+
     spawnTool(
       ['tools/generate-images.ts', '--word', testWord, '--force'],
-      { env: DEMO_ENV, timeout: 30000 },
+      { env: { ...DEMO_ENV, IMAGES_OUTPUT_DIR: outputDir }, timeout: 30000 },
       ({ stdout, stderr, code }) => {
-        expect(code).toBe(0);
-        expect(stdout).toContain('Generate images tool starting');
-        expect(stdout).toContain(`Generated image for word`);
-        expect(stderr).not.toContain('astro:');
-        expect(stderr).not.toContain('Only URLs with a scheme in: file, data, and node');
-        done();
+        try {
+          expect(code).toBe(0);
+          expect(stdout).toContain('Generate images tool starting');
+          expect(stdout).toContain(`Generated image for word`);
+          expect(stderr).not.toContain('astro:');
+          expect(stderr).not.toContain('Only URLs with a scheme in: file, data, and node');
+          // The card landed in the temp dir, not the tracked public/ tree.
+          const generated = fs.readdirSync(outputDir, { recursive: true })
+            .filter(entry => String(entry).endsWith('.png'));
+          expect(generated.length).toBeGreaterThan(0);
+          done();
+        } catch (error) {
+          done(error);
+        } finally {
+          fs.rmSync(outputDir, { recursive: true, force: true });
+        }
       },
     );
   }, 35000);


### PR DESCRIPTION
## Summary

- The cli-integration test spawned `generate-images` with `--force` against the first demo word, so every `npm test` regenerated and overwrote the tracked card at `public/demo/images/social/2023/20230101-japan.png`, leaving a dirty file on every run that's easy to stage by accident.
- Added an `IMAGES_OUTPUT_DIR` override to the images path resolver in `config/paths.ts` so generation can target any directory, and pointed the test at an OS temp dir it cleans up afterward. Default output is unchanged, only the test sets the override, and it still asserts a PNG landed in the temp dir so end-to-end generation still works.

## Test plan

- [x] Quality gates pass (lint, typecheck, test, build)
- [x] Relevant tests added or updated (the generate-images integration test now redirects output and asserts it)
- [x] Manual verification: confirmed a full `npm test` no longer leaves `…/20230101-japan.png` modified (was dirty on every run before)
